### PR TITLE
Release strict stateless OpenRouter MCP 3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # OpenRouter API Configuration
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+# Optional management key for credits, account activity, and analytics
+OPENROUTER_MANAGEMENT_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_TIMEOUT_MS=60000
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
 # OpenRouter MCP server
 
-This server gives Claude four OpenRouter tools. Claude can list models, inspect one model, generate a response, or compare models. Three resources expose model metadata, pricing, and API-key usage.
+This project connects agents to OpenRouter through two front doors: an agent-first command-line interface and a strict stateless MCP server. Both use the same operation layer and stable response shapes. The MCP server exposes thirteen focused tools and one API-key usage resource.
 
-Version 2.0 targets MCP `2026-07-28` only. Current Claude clients can send stateless requests directly. The server rejects clients that begin with the legacy `initialize` handshake.
+Version 3.0 targets MCP `2026-07-28` only. Each HTTP POST is independent. The server does not accept `initialize`, create `Mcp-Session-Id` sessions, expose a GET event stream, or run a legacy fallback.
 
-## What changed in 2.0
+## What changed in 3.0
 
-- Modern HTTP requests do not use `initialize`, `notifications/initialized`, `Mcp-Session-Id`, or a GET event stream. Legacy openings are rejected.
-- `server/discover` reports server capabilities. Every request carries protocol, client, and capability metadata.
-- `serveStdio` pins each accepted stdio connection to MCP `2026-07-28` and rejects legacy mode.
-- Each tool has a strict Zod input schema, effect annotations, and structured output.
-- The server passes MCP cancellation to every in-flight OpenRouter request.
-- OpenRouter attribution sends `X-OpenRouter-Title`.
-- `chat_with_model` sends `max_completion_tokens`. It still accepts `max_tokens` as a deprecated alias.
-- `openrouter://usage` calls OpenRouter's current-key endpoint instead of returning placeholder data.
-- `list_models` limits each result page with `limit` and `offset`.
+- `list_models` sends pagination, filters, and sorting to OpenRouter instead of downloading the full catalog.
+- `get_model` calls OpenRouter's direct model endpoint. It replaces `get_model_info`; there is no alias.
+- `list_model_endpoints` returns provider price, context, uptime, latency, throughput, and supported parameters.
+- `list_providers` exposes provider geography, policy links, and service-status metadata without a browser.
+- `list_model_rankings` and `list_app_rankings` expose bounded versions of OpenRouter's public rankings pages.
+- `get_credits` and `list_activity` expose account data with a separate management-key boundary.
+- `get_analytics_schema` and `query_analytics` expose the current Activity Explore analytics contract with explicit time ranges and bounded results.
+- `chat_with_model` and `compare_models` return a `generation_id` and the resolved model.
+- `get_generation` uses that ID to fetch exact provider, token, latency, and cost metadata.
+- The `openrouter-mcp` CLI exposes the same operations directly, emits JSON automatically when piped, and never prompts.
+- Browser inspection informed the surface contract, but no browser, cookie, HAR file, or browser session is required at runtime.
+- `openrouter://models` and `openrouter://pricing` were removed. Their unbounded catalog payloads are not retained as fallbacks.
+- Unknown fields added by OpenRouter are stripped at the API boundary. The MCP output schemas remain stable.
+- Static discovery responses declare a one-hour public cache hint. API-key usage remains private with a five-second hint.
+- Model comparisons run at most three OpenRouter calls at once. Paid calls are never retried automatically.
+- Custom OpenRouter base URLs must use HTTPS. Plain HTTP is accepted only for loopback development.
 
-See [docs/MCP-2026-07-28.md](docs/MCP-2026-07-28.md) for the wire-level changes.
+See [docs/API.md](docs/API.md) for the complete tool contract, [docs/CLI.md](docs/CLI.md) for direct CLI use, and [docs/MCP-2026-07-28.md](docs/MCP-2026-07-28.md) for wire-level behavior.
 
 ## Requirements
 
 - Node.js 24 LTS
 - pnpm 12.0.0, exactly as pinned in `package.json`
-- An OpenRouter API key for chat, model comparison, and key-usage data
+- An OpenRouter API key for rankings, inference, generation metadata, and key-usage data
+- An OpenRouter management key for credit totals, account activity, and analytics
 
-Model discovery can work without a key. OpenRouter may still apply anonymous limits.
+OpenRouter currently serves public model and provider discovery without a key. That anonymous behavior may be rate-limited or changed upstream.
 
 ## Install
 
@@ -43,13 +51,31 @@ Copy `.env.example` to `.env`, then set:
 
 ~~~dotenv
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+# Optional; required only for get_credits and list_activity
+OPENROUTER_MANAGEMENT_KEY=your_openrouter_management_key_here
 ~~~
 
 Keep `.env` out of Git.
 
+## Use the CLI
+
+Build once, then call the same operations without starting an MCP client:
+
+~~~bash
+pnpm run build
+node dist/cli.js schema
+node dist/cli.js models list --q claude --limit 5
+node dist/cli.js providers list --datacenter DE
+node dist/cli.js rankings models --limit 10
+node dist/cli.js account credits
+node dist/cli.js analytics schema
+~~~
+
+Interactive terminals receive compact text or tables. Redirected output is JSON automatically; `--json` makes that behavior explicit. Diagnostics use `stderr`, usage failures exit with status 2, operation failures exit with status 1, and commands never prompt. Run the strict stateless server through the same binary with `node dist/cli.js serve --transport stdio`.
+
 ## Use with Claude over stdio
 
-`stdio` is the default. Use it for local Claude integrations.
+`stdio` is the default transport for local Claude integrations.
 
 ~~~bash
 pnpm run build
@@ -90,32 +116,50 @@ Do not expose this listener directly to the internet. Put an HTTPS gateway that 
 
 | Tool | Purpose | External effect |
 | --- | --- | --- |
-| list_models | Search and page through current model metadata | Read-only OpenRouter request |
-| get_model_info | Read one exact model record | Read-only OpenRouter request |
-| chat_with_model | Generate one response | Can consume API credits |
-| compare_models | Generate with two to eight models | Can consume API credits per model |
+| `list_models` | Search, filter, sort, and page the live model catalog | Read-only OpenRouter request |
+| `get_model` | Read one exact model, variant, or alias | Read-only OpenRouter request |
+| `list_model_endpoints` | Compare the providers serving one model | Read-only OpenRouter request |
+| `list_providers` | Filter providers by name, headquarters, or datacenter | Read-only public request |
+| `list_model_rankings` | Read one completed UTC day of model rankings | Read-only API-key request |
+| `list_app_rankings` | Read popular or trending public apps | Read-only API-key request |
+| `get_credits` | Read purchased, used, and remaining credits | Read-only management request |
+| `list_activity` | Read endpoint-level daily account activity | Read-only management request |
+| `get_analytics_schema` | Discover current analytics metrics, dimensions, operators, and granularities | Read-only management request |
+| `query_analytics` | Query bounded Activity Explore aggregates over an explicit time range | Read-only management request |
+| `chat_with_model` | Generate one response and return its generation ID | Can consume API credits |
+| `compare_models` | Generate with two to eight models, three calls at a time | Can consume API credits per model |
+| `get_generation` | Read provider, tokens, latency, and cost for one generation ID | Read-only authenticated request |
 
-Each tool returns a text block and `structuredContent`. Zod rejects bad input before the handler runs. The SDK converts upstream failures into MCP tool errors.
+Each tool returns a text block and `structuredContent`. Zod rejects invalid input before the handler runs. The SDK converts upstream failures into MCP tool errors.
 
-## Resources
+## Resource
 
-| URI | Data |
-| --- | --- |
-| openrouter://models | Current model metadata |
-| openrouter://pricing | Current pricing fields |
-| openrouter://usage | Usage and limits for the configured API key |
+| URI | Data | Cache hint |
+| --- | --- | --- |
+| `openrouter://usage` | Usage and limits for the configured API key | Private, five seconds |
+
+Model and pricing catalogs are tools rather than resources so every response can be filtered and bounded.
+
+## Verify the live API
+
+~~~bash
+pnpm run test:live
+~~~
+
+The command always checks live model pagination, direct model lookup, model endpoints, and provider discovery. If `OPENROUTER_API_KEY` is configured, it also checks both ranking datasets, sends one short request through `openrouter/free`, and resolves the returned generation metadata. If `OPENROUTER_MANAGEMENT_KEY` is configured, it checks credits, bounded activity, analytics schema discovery, and a small seven-day analytics query. The report never prints a credential or generation ID.
 
 ## Environment
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| OPENROUTER_API_KEY | none | OpenRouter API key |
-| OPENROUTER_BASE_URL | https://openrouter.ai/api/v1 | OpenRouter API base URL |
-| OPENROUTER_SITE_URL | none | Optional HTTP-Referer app attribution |
-| OPENROUTER_APP_NAME | OpenRouter MCP Server | X-OpenRouter-Title attribution |
-| OPENROUTER_TIMEOUT_MS | 60000 | Per-request timeout |
-| MCP_TRANSPORT | stdio | stdio or http |
-| MCP_HTTP_PORT | 3000 | Local HTTP port |
+| `OPENROUTER_API_KEY` | none | OpenRouter key for rankings, inference, generation metadata, and `openrouter://usage` |
+| `OPENROUTER_MANAGEMENT_KEY` | `OPENROUTER_API_KEY` | OpenRouter management key for credits, account activity, and analytics |
+| `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1` | HTTPS OpenRouter API base URL; HTTP is loopback-only |
+| `OPENROUTER_SITE_URL` | none | Optional `HTTP-Referer` app attribution |
+| `OPENROUTER_APP_NAME` | `OpenRouter MCP Server` | `X-OpenRouter-Title` attribution |
+| `OPENROUTER_TIMEOUT_MS` | `60000` | Per-request timeout |
+| `MCP_TRANSPORT` | `stdio` | `stdio` or `http` |
+| `MCP_HTTP_PORT` | `3000` | Local HTTP port |
 
 Command-line `--transport` and `--port` values override their environment variables.
 
@@ -131,15 +175,24 @@ pnpm run build
 pnpm run check
 ~~~
 
-The tests send a `2026-07-28` request without `initialize` and exercise strict legacy rejection, structured results, tool errors, and cancellation. They also start the real stdio entry point and inspect the OpenRouter request headers.
+The deterministic tests cover modern HTTP without `initialize`, strict legacy rejection, real stdio negotiation, CLI schema output, cache hints, credential separation, upstream and local pagination, direct API routes, generation handles, comparison concurrency, cancellation, schema drift, bounded errors, and HTTPS enforcement. The live contract test is separate because it depends on current network and OpenRouter availability.
 
 ## Sources
 
+- [OpenRouter MCP server](https://openrouter.ai/docs/guides/overview/mcp-server)
+- [OpenRouter models API](https://openrouter.ai/docs/api/api-reference/models/list-all-models-and-their-properties)
+- [OpenRouter model endpoints API](https://openrouter.ai/docs/api/api-reference/endpoints/list-all-endpoints-for-a-model)
+- [OpenRouter generation metadata API](https://openrouter.ai/docs/api/api-reference/generations/get-request-&-usage-metadata-for-a-generation)
+- [OpenRouter TypeScript SDK endpoint functions](https://github.com/OpenRouterTeam/typescript-sdk/tree/main/src/funcs)
+- [OpenRouter Analytics API](https://openrouter.ai/docs/api/api-reference/analytics/query-analytics-data)
+- [OpenRouter analytics schema](https://openrouter.ai/docs/api/api-reference/analytics/get-available-analytics-metrics-and-dimensions)
+- [Railly Hugo: reverse engineering and agent-built CLIs](https://www.youtube.com/watch?v=jbkxdxJfQ60)
+- [Surface Recon skill](https://github.com/crafter-station/skills/blob/main/skills/surface-recon/SKILL.md)
+- [CLI Build skill](https://github.com/crafter-station/skills/blob/main/skills/cli-build/SKILL.md)
 - [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [Official TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
 - [Claude Code MCP quickstart](https://code.claude.com/docs/en/mcp-quickstart)
-- [OpenRouter API documentation](https://openrouter.ai/docs/api/reference/overview)
 
 ## License
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,42 +1,233 @@
 # OpenRouter MCP API
 
-The server exposes four tools and three fixed resources. MCP `2026-07-28` clients call them directly. The server rejects legacy `initialize` clients.
+Version 3.0 exposes thirteen tools and one fixed resource. MCP `2026-07-28` clients call them directly. The server rejects legacy `initialize` clients.
 
-## list_models
+All tools use strict input schemas and return both a JSON text block and matching `structuredContent`.
 
-Search and page through model metadata.
+Public model and provider discovery send no authorization header. Rankings, inference, generation metadata, and `openrouter://usage` use `OPENROUTER_API_KEY`. Credits, activity, and analytics use `OPENROUTER_MANAGEMENT_KEY`; an actual management key may instead be supplied through `OPENROUTER_API_KEY`.
 
-Input:
+## `list_models`
+
+Search, filter, sort, and page OpenRouter's live model catalog. Pagination runs at OpenRouter; the MCP server does not fetch the complete catalog and slice it locally.
 
 ~~~json
 {
-  "q": "optional text query",
+  "q": "claude",
+  "sort": "coding-high-to-low",
+  "providers": ["Anthropic", "Amazon Bedrock"],
+  "supported_parameters": ["tools", "structured_outputs"],
+  "min_context_length": 128000,
+  "max_prompt_price": 5,
   "limit": 25,
   "offset": 0
 }
 ~~~
 
-- `q` is optional. The server passes it to OpenRouter's model endpoint.
-- `limit` defaults to 25 and accepts values from 1 through 100.
-- `offset` defaults to 0.
+### Discovery fields
 
-The response's `structuredContent` contains `models`, `total_available`, `returned`, `offset`, and `next_offset`.
+| Field | Constraint | Meaning |
+| --- | --- | --- |
+| `q` | 1–200 characters | Model name or slug search |
+| `category` | OpenRouter category enum | Use-case category |
+| `architecture` | 1–100 characters | Architecture or family, such as Claude or Llama |
+| `model_authors` | 1–20 strings | Organizations that created the model |
+| `providers` | 1–20 strings | Hosting providers that must serve the model |
+| `supported_parameters` | 1–20 strings | Required inference parameters |
+| `input_modalities` | text, image, audio, file | Required input types |
+| `output_modalities` | modality array or `all` | Required output types; `all` disables OpenRouter's text default |
+| `distillable` | boolean | Include or exclude distillable models |
+| `zdr` | `true` only | Require a zero-data-retention endpoint |
+| `region` | `eu` or `us` | Require an endpoint in the selected region |
 
-## get_model_info
+### Numeric filters
 
-Read the current metadata for one exact model ID.
+| Range | Fields |
+| --- | --- |
+| Context tokens | `min_context_length` |
+| Prompt price in USD per million tokens | `min_prompt_price`, `max_prompt_price` |
+| Output price in USD per million tokens | `min_output_price`, `max_output_price` |
+| Model age in days | `min_age_days`, `max_age_days` |
+| Artificial Analysis intelligence | `min_intelligence_index`, `max_intelligence_index` |
+| Artificial Analysis coding | `min_coding_index`, `max_coding_index` |
+| Artificial Analysis agentic | `min_agentic_index`, `max_agentic_index` |
+| Tool success fraction from 0 through 1 | `min_tool_success_rate`, `max_tool_success_rate` |
+
+Each minimum must be less than or equal to its matching maximum.
+
+### Sorting and pagination
+
+`sort` accepts:
+
+- `most-popular`
+- `newest`
+- `top-weekly`
+- `pricing-low-to-high`
+- `pricing-high-to-low`
+- `context-high-to-low`
+- `throughput-high-to-low`
+- `latency-low-to-high`
+- `intelligence-high-to-low`
+- `coding-high-to-low`
+- `agentic-high-to-low`
+- `design-arena-elo-high-to-low`
+
+`limit` defaults to 25 and accepts 1 through 100. `offset` defaults to 0.
+
+The result contains `models`, `total_count`, `returned`, `offset`, `has_more`, and `next_offset`. Each model is a compact selection record. Use `get_model` for its description, supported parameters, reasoning settings, and full benchmark data.
+
+## `get_model`
+
+Read current metadata for one exact `author/slug`. OpenRouter variants such as `:free` and known aliases are passed to the direct model endpoint.
 
 ~~~json
 {
-  "model": "provider/model-id"
+  "model": "provider/model-id:free"
 }
 ~~~
 
-The handler returns an MCP tool error when the ID does not exist.
+The result contains one normalized `model`. Unknown fields added by OpenRouter are stripped. Missing or malformed documented fields still fail validation.
 
-## chat_with_model
+`get_model_info` was removed in 3.0. There is no compatibility alias.
 
-Generate one response. This call can spend OpenRouter API credits.
+## `list_model_endpoints`
+
+List the providers serving one model.
+
+~~~json
+{
+  "model": "provider/model-id",
+  "provider": "Bedrock",
+  "limit": 25,
+  "offset": 0
+}
+~~~
+
+`provider` is an optional case-insensitive match against provider name, endpoint tag, or endpoint name. The result is locally bounded and contains `endpoints`, `total_count`, `returned`, `offset`, `has_more`, and `next_offset`.
+
+Endpoint records can include:
+
+- prompt, completion, cache, image, audio, request, and override pricing;
+- context and completion limits;
+- supported inference parameters and tool-choice modes;
+- quantization and endpoint tag;
+- five-minute, 30-minute, and one-day uptime;
+- recent latency and throughput percentiles.
+
+## `list_providers`
+
+List OpenRouter providers and filter the bounded result locally.
+
+~~~json
+{
+  "q": "cloud",
+  "headquarters": "US",
+  "datacenter": "DE",
+  "limit": 50,
+  "offset": 0
+}
+~~~
+
+Country filters use two-letter codes. Provider records contain name, slug, headquarters, datacenter countries, privacy-policy URL, terms URL, and status-page URL when OpenRouter supplies them. The result contains `providers`, `total_count`, `returned`, `offset`, `has_more`, and `next_offset`.
+
+## `list_model_rankings`
+
+Read a bounded model-usage ranking for one completed UTC day. A regular OpenRouter API key is required.
+
+~~~json
+{
+  "date": "2026-08-30",
+  "modality": "tool_calling",
+  "context_bucket": "100K",
+  "include_other": false,
+  "limit": 20
+}
+~~~
+
+`date` defaults to the last completed UTC day. `modality` accepts `text`, `image`, `image_output`, `audio`, or `tool_calling`; `context_bucket` accepts `1K`, `10K`, `100K`, `1M`, or `10M`. The server requests a one-day window, excludes OpenRouter's aggregated `other` row by default, limits the result to 50 rows, assigns ranks after filtering, and includes source attribution plus upstream `meta` timestamps.
+
+## `list_app_rankings`
+
+Read the public app marketplace through OpenRouter's Data API. A regular OpenRouter API key is required.
+
+~~~json
+{
+  "category": "coding",
+  "subcategory": "cli-agent",
+  "sort": "trending",
+  "start_date": "2026-08-01",
+  "end_date": "2026-08-30",
+  "limit": 25,
+  "offset": 0
+}
+~~~
+
+`sort` accepts `popular` or `trending`. Pages contain at most 100 rows; `offset` is capped at 100. The result includes app rank, request count, token count, source attribution, upstream metadata, and bounded pagination fields.
+
+## `get_credits`
+
+Return `total_credits`, `total_usage`, and locally computed `remaining_credits`. This read-only call requires a management key.
+
+~~~json
+{}
+~~~
+
+## `list_activity`
+
+Read endpoint-level account usage for one of OpenRouter's last 30 completed UTC days. This read-only call requires a management key.
+
+~~~json
+{
+  "date": "2026-08-30",
+  "api_key_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
+  "group_by": "workspace",
+  "limit": 50,
+  "offset": 0
+}
+~~~
+
+`date` defaults to the last completed UTC day. Optional filters are `api_key_hash`, `user_id`, and `workspace_id`. `group_by: "workspace"` makes OpenRouter split rows per workspace instead of aggregating across workspaces. The server applies bounded local pagination and returns model, endpoint, provider, request, token, BYOK, and usage totals.
+
+## `get_analytics_schema`
+
+Discover the current contract for the aggregates behind OpenRouter's Activity Explore browser view. This call requires a management key.
+
+~~~json
+{}
+~~~
+
+The result lists current metrics, dimensions, filter operators, and time granularities with display labels. Agents should call this tool before `query_analytics` because OpenRouter can add analytics fields without a server release.
+
+## `query_analytics`
+
+Run a bounded read-only analytics query with the same aggregate data used by Activity Explore. This call requires a management key.
+
+~~~json
+{
+  "metrics": ["total_usage", "request_count", "tokens_total"],
+  "dimensions": ["model"],
+  "granularity": "day",
+  "filters": [
+    { "field": "provider", "operator": "eq", "value": "Anthropic" }
+  ],
+  "order_by": { "field": "total_usage", "direction": "desc" },
+  "time_range": {
+    "start": "2026-08-01T00:00:00Z",
+    "end": "2026-08-31T00:00:00Z"
+  },
+  "limit": 1000
+}
+~~~
+
+The wrapper requires an explicit UTC `time_range`; timestamps must include seconds. Queries accept one through 50 current metric names, up to two dimensions, up to 20 filters, optional minute/hour/day/week/month granularity, and at most 10,000 rows. `group_limit` can independently cap rows per dimension combination.
+
+Standard filters accept `eq`, `neq`, `in`, `not_in`, `gt`, `gte`, `lt`, and `lte`. Set operators require an array value; other operators require a scalar. Optional `classifier_dimensions` and `classifier_filters` expose classifier tags with one matching classifier UUID, up to ten dimension names, and up to ten equality or set filters.
+
+The result contains dynamic `rows` keyed by the requested fields, `metadata.query_time_ms`, `metadata.row_count`, `metadata.truncated`, and optional cache and warning fields. Count and token metrics may be strings. Callers must treat a result with `metadata.truncated: true` as partial.
+
+## `chat_with_model`
+
+Generate one response. This call can consume OpenRouter API credits and is not retried automatically.
 
 ~~~json
 {
@@ -48,15 +239,21 @@ Generate one response. This call can spend OpenRouter API credits.
 }
 ~~~
 
-- `max_completion_tokens` defaults to 1000.
-- `max_tokens` is a deprecated compatibility alias.
-- `temperature` defaults to 0.7 and accepts values from 0 through 2.
+`max_completion_tokens` defaults to 1000. `temperature` defaults to 0.7 and accepts 0 through 2.
 
-The response's `structuredContent` contains `model`, `response`, and `usage`.
+The result contains:
 
-## compare_models
+- `generation_id`: explicit handle for `get_generation`;
+- `requested_model`: the model supplied by the caller;
+- `resolved_model`: the model reported by OpenRouter after routing, or `null`;
+- `response`;
+- `usage`.
 
-Generate the same prompt with two to eight model IDs. The server makes one OpenRouter request per model, so one tool call can spend credits several times.
+The deprecated `max_tokens` alias was removed in 3.0.
+
+## `compare_models`
+
+Generate the same prompt with two through eight unique model IDs. One tool call can consume credits once per model.
 
 ~~~json
 {
@@ -66,27 +263,45 @@ Generate the same prompt with two to eight model IDs. The server makes one OpenR
 }
 ~~~
 
-The result contains one success or error record per model. Cancelling the MCP call aborts every in-flight request.
+At most three upstream calls run at once. Calls are not retried. Each success record contains its own `generation_id`, requested model, resolved model, response, and usage. One provider failure becomes an error record without discarding successful results. Cancelling the MCP call aborts every active request.
 
-## Resources
+## `get_generation`
 
-### openrouter://models
+Resolve an explicit generation handle. The server does not keep request history or session state.
 
-OpenRouter's current model metadata. The resource declares a private 60-second cache hint.
+~~~json
+{
+  "generation_id": "gen-1234567890"
+}
+~~~
 
-### openrouter://pricing
+The result can include the exact model, provider, prompt and completion tokens, native token counts, latency, generation time, finish reason, routing tier, region, and total cost reported by OpenRouter.
 
-Model ID, name, and pricing fields, including token-, time-, and cache-specific pricing overrides. The resource declares a private 60-second cache hint.
+## Resource
 
-### openrouter://usage
+### `openrouter://usage`
 
 Usage and limits from OpenRouter's current-key endpoint. The resource declares a private five-second cache hint.
 
-## Errors
+`openrouter://models` and `openrouter://pricing` were removed in 3.0. Use bounded model tools instead.
+
+## Caching
+
+The server returns a public one-hour cache hint for:
+
+- `server/discover`;
+- `tools/list`;
+- `resources/list`;
+- `resources/templates/list`.
+
+The tool and resource definitions do not vary by API key. Account data remains private.
+
+## Errors and cancellation
 
 - Zod validates tool input before the handler runs.
 - The SDK returns validation and upstream exceptions with `isError` set.
 - Resource failures are protocol errors.
-- `OpenRouterClient` truncates upstream error messages to 1,000 characters.
-- The server never includes API keys in tool results or errors.
-- Each upstream request has a timeout and receives the MCP cancellation signal.
+- OpenRouter error messages are flattened to one line and limited to 1,000 characters.
+- API keys are never included in results or errors.
+- Every upstream request has a timeout and receives the MCP cancellation signal.
+- Non-loopback OpenRouter base URLs must use HTTPS.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,109 @@
+# OpenRouter CLI
+
+The `openrouter-mcp` binary is a direct, non-interactive front door to the same operations used by the MCP server. It does not start a browser or preserve a session.
+
+## Output contract
+
+When output is redirected or piped, every operation writes one JSON object to `stdout`:
+
+~~~json
+{
+  "ok": true,
+  "command": "providers.list",
+  "data": {},
+  "next_steps": ["models list --providers <provider>"]
+}
+~~~
+
+Use `--json` to request the same contract in an interactive terminal. Human-readable tables are the interactive default. Diagnostics and errors go to `stderr`.
+
+| Exit status | Meaning |
+| --- | --- |
+| `0` | Success |
+| `1` | OpenRouter, network, or runtime operation failed |
+| `2` | Invalid command, option, or value |
+
+The CLI never prompts. Credentials are read only from environment variables or `.env`.
+
+## Agent-readable schema
+
+~~~bash
+openrouter-mcp schema
+~~~
+
+The versioned result describes every command's usage, options, MCP equivalent, credential class, risk class, output behavior, and exit statuses. This is the most stable entry point for an agent that needs to discover the CLI contract.
+
+## Commands
+
+| CLI command | MCP equivalent | Credential |
+| --- | --- | --- |
+| `models list [options]` | `list_models` | None |
+| `models get <author/slug>` | `get_model` | None |
+| `models endpoints <author/slug> [options]` | `list_model_endpoints` | None |
+| `providers list [options]` | `list_providers` | None |
+| `rankings models [options]` | `list_model_rankings` | API key |
+| `rankings apps [options]` | `list_app_rankings` | API key |
+| `account credits` | `get_credits` | Management key |
+| `activity list [options]` | `list_activity` | Management key |
+| `analytics schema` | `get_analytics_schema` | Management key |
+| `analytics query [options]` | `query_analytics` | Management key |
+| `chat send [options]` | `chat_with_model` | API key; can consume credits |
+| `chat compare [options]` | `compare_models` | API key; can consume credits per model |
+| `generations get <generation-id>` | `get_generation` | API key |
+| `serve [options]` | Starts the MCP server | Depends on called tools |
+
+Run `openrouter-mcp --help` for the short command map. Run `openrouter-mcp schema --json` for the complete machine-readable option inventory.
+
+## Examples
+
+~~~bash
+# Filter the live catalog
+openrouter-mcp models list --q claude --min-context-length 128000 --limit 10
+
+# Find providers with a German datacenter
+openrouter-mcp providers list --datacenter DE
+
+# Read the last completed UTC day's model ranking
+openrouter-mcp rankings models --modality tool_calling --limit 20
+
+# Read trending coding apps in a bounded page
+openrouter-mcp rankings apps --category coding --sort trending --limit 25 --offset 0
+
+# Read one day's endpoint-level activity
+openrouter-mcp activity list --date 2026-08-30 --limit 50
+
+# Discover the current analytics vocabulary before building a query
+openrouter-mcp analytics schema
+
+# Query the aggregates behind Activity Explore
+openrouter-mcp analytics query \
+  --metrics total_usage,request_count,tokens_total \
+  --dimensions model \
+  --start 2026-08-01T00:00:00Z \
+  --end 2026-08-31T00:00:00Z \
+  --order-by total_usage \
+  --order-direction desc \
+  --limit 20
+
+# Make one inference call
+openrouter-mcp chat send \
+  --model openrouter/free \
+  --message "Reply with OK." \
+  --max-completion-tokens 4 \
+  --temperature 0
+
+# Run strict stateless MCP over stdio
+openrouter-mcp serve --transport stdio
+~~~
+
+PowerShell uses the same command and option names. Use backticks instead of backslashes when splitting one command across lines.
+
+## Authentication boundaries
+
+`OPENROUTER_API_KEY` authorizes rankings, inference, generation metadata, and the `openrouter://usage` resource. `OPENROUTER_MANAGEMENT_KEY` authorizes credit totals, activity, and analytics. If the management variable is absent, the client falls back to `OPENROUTER_API_KEY` so an actual management key can be supplied through either name; an ordinary API key does not gain management permissions.
+
+Public model and provider discovery send no authorization header, even when a key is configured.
+
+## Why the browser is not part of the runtime
+
+The browser-oriented workflow was used as reconnaissance: identify valuable UI surfaces, trace them to stable upstream contracts, and then expose only bounded operations that have an official API. The shipped CLI and MCP server call OpenRouter directly. They do not depend on DOM selectors, private cookies, a persistent browser profile, or replayed browser traffic.

--- a/docs/ENGINEERING-NOTES-STATELESS-MCP-2026-07-28.md
+++ b/docs/ENGINEERING-NOTES-STATELESS-MCP-2026-07-28.md
@@ -1,0 +1,298 @@
+# Stateless MCP 2026-07-28 overhaul
+
+Status: implementation and local verification note for the 3.0.0 release reviewed on 2026-08-31 in America/Caracas (2026-09-01 UTC).
+
+This note separates four kinds of claims:
+
+- **Upstream fact**: stated by an official MCP, Anthropic, OpenRouter, Node.js, npm, or pnpm source.
+- **Implementation decision**: behavior selected by this repository. It may be stricter than the upstream protocol.
+- **Local verification**: observed in this checkout on the date above.
+- **Remaining limitation**: not proved locally, intentionally unsupported, or dependent on external state.
+
+## Executive summary
+
+MCP 2026-07-28 changes the normal server interaction from a connection-level initialization lifecycle to self-contained requests. Each modern request carries its protocol version, client identity, and capabilities. HTTP remains one POST endpoint, with either a JSON response or request-scoped server-sent events. The old long-lived GET event stream and session identifier are not part of the modern core. See the [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28/) and [transport specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports).
+
+The current workspace implements that protocol as a strict boundary. It rejects the SDK's legacy fallback on both HTTP and stdio. It also disables the compatibility shim for missing tool input. This is a repository policy, not a protocol requirement.
+
+The OpenRouter integration now has two thin adapters over one operations layer:
+
+```text
+MCP tools and resource ─┐
+                       ├─> bounded operations ─> OpenRouter HTTP client ─> OpenRouter APIs
+direct CLI commands ───┘
+```
+
+The MCP surface has 13 fixed tools and one fixed resource, `openrouter://usage`. The CLI exposes the same 13 operations plus `serve`. No server-side conversation, job, or pagination session is needed between requests.
+
+Local source checks, type checks, lint, unit and integration-style tests, builds, built-entry handshakes, and package dry runs pass. Anonymous live discovery passed for the model catalog, one exact model endpoint, and the provider list. Valid inference-key and management-key behavior was not proved because the available authenticated paths returned 401 or were not configured.
+
+## 1. What MCP 2026-07-28 changed
+
+### Stateless request metadata
+
+**Upstream fact.** The 2026-07-28 core removes the required `initialize` / `initialized` exchange from the normal modern flow. Every request carries protocol version, client information, and client capabilities. `Mcp-Session-Id` is not part of the modern request contract. A server can expose optional `server/discover` metadata. The release calls out explicit handles when application state must survive across requests. See [MCP 2026-07-28](https://blog.modelcontextprotocol.io/posts/2026-07-28/).
+
+**Implementation decision.** This server keeps cross-request state out of the MCP process. A paid chat call returns the OpenRouter generation ID. `get_generation` accepts that explicit ID later. The server does not retain a hidden conversation or generation registry. See [`src/operations.ts`](../src/operations.ts) and [`src/mcp.ts`](../src/mcp.ts).
+
+### Request-response HTTP
+
+**Upstream fact.** Streamable HTTP sends each MCP message to one endpoint with POST. A server can return a single JSON response or use server-sent events for that request. The modern core does not allow server-initiated requests. Cancellation closes the HTTP response stream; stdio uses a cancellation notification. See the [2026-07-28 transport specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports).
+
+**Implementation decision.** The local HTTP transport binds only to `127.0.0.1`, accepts MCP POST requests at `/mcp`, validates Host and Origin, and returns 405 to GET. There is no legacy GET event stream. Stdio remains the default. See [`src/server.ts`](../src/server.ts).
+
+### Discovery and cache hints
+
+**Upstream fact.** The protocol defines `ttlMs` and `cacheScope` hints for discovery and resource results. `public` means the response is not user-specific. `private` means it can contain user-specific data. The TTL is a reuse hint, not a correctness guarantee. See [MCP caching](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching).
+
+**Implementation decision.** `server/discover`, `tools/list`, `resources/list`, and `resources/templates/list` receive a public one-hour cache hint. `openrouter://usage` receives a private five-second cache hint because it describes the configured API key. The usage value is still fetched on resource read; the server does not keep its own cache.
+
+### Claude adoption
+
+**Upstream fact.** Anthropic announced a rollout of MCP 2026-07-28 across Claude products. That announcement is evidence of adoption work, not proof that every Claude client version already speaks only the new protocol. See [Bringing MCP 2026-07-28 to Claude](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude) and the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
+
+**Remaining limitation.** This checkout was exercised with the official MCP 2.0.0 client package. It was not connected end to end to every Claude desktop, web, or Code release.
+
+## 2. Repository chronology and the old behavior
+
+The history has three distinct states. Keeping them separate matters because the strict protocol fallback removal landed before the larger 3.0.0 API and CLI expansion.
+
+### Original implementation — before `1d6d2ad`
+
+- **Protocol and transport:** Connection-oriented legacy SDK over stdio only.
+- **OpenRouter surface:** Four tools: `list_models`, `chat_with_model`, `compare_models`, and `get_model_info`; three resources: models, pricing, and usage.
+- **Main constraints:** Monolithic server file; Axios; full-catalog lookup; `Promise.all` comparison fan-out; `max_tokens`; placeholder usage data.
+
+### Committed 2.0.0 — `de90005`
+
+- **Protocol and transport:** Stateless 2026-07-28 server over HTTP and stdio. The SDK fallback was already set to `legacy: "reject"`.
+- **OpenRouter surface:** Four modern tools and three resources.
+- **Main constraints:** The modern protocol core was in place, but the API surface was smaller and compatibility names and resources remained.
+
+### 3.0.0 release workspace
+
+- **Protocol and transport:** The same strict protocol policy, with the compatibility shim disabled and stronger transport checks.
+- **OpenRouter surface:** 13 tools, one resource, and a direct CLI over shared operations.
+- **Main constraints:** This is a deliberate breaking migration. Authenticated OpenRouter paths still need live credentials.
+
+**Local verification.** `git show` confirms the original four tool names, three resource URIs, Axios-based client, `StdioServerTransport`, `max_tokens`, and unbounded `Promise.all` comparison. The current branch history is `1d6d2ad` for the stateless overhaul, `a8da369` for legacy fallback removal, and `de90005` for pricing parsing. No history was rewritten during this review.
+
+## 3. Strict modern-only policy
+
+**Upstream fact.** The MCP TypeScript 2.0 migration guidance says `createMcpHandler` can serve modern requests while retaining a legacy 2025 fallback by default. `serveStdio` can also support the legacy path. Passing `legacy: "reject"` makes either boundary modern-only. Setting `inputRequired.legacyShim` to `false` rejects missing input instead of applying the old shim. See the [TypeScript SDK 2026-07-28 migration guide](https://ts.sdk.modelcontextprotocol.io/v2/migration/support-2026-07-28).
+
+**Implementation decision.** Both adapters pass `legacy: "reject"`. Tool registration passes `inputRequired: { legacyShim: false }`. There is no automatic downgrade, initialization bridge, or alternate legacy endpoint.
+
+**Migration consequence.** A client that starts with protocol `2025-11-25`, expects `initialize`, uses the old GET stream, or omits modern request metadata will fail. The local verifier reproduced this rejection when it used the MCP client's legacy default. Pinning the client to `2026-07-28` made both built stdio entry points pass.
+
+This strictness reduces ambiguous dual-protocol behavior. It also makes the compatibility break immediate. Operators must upgrade or correctly configure clients before replacing a 2.x deployment.
+
+## 4. Shared operations layer and direct CLI
+
+**Implementation decision.** [`src/operations.ts`](../src/operations.ts) owns filtering, pagination envelopes, bounded comparison scheduling, completed-date selection, and response shaping. [`src/mcp.ts`](../src/mcp.ts) validates MCP inputs and registers the fixed MCP surface. [`src/cli.ts`](../src/cli.ts) parses non-interactive commands and renders JSON or human text. [`src/openrouter.ts`](../src/openrouter.ts) owns HTTP, credentials, transport security, timeouts, and upstream schema validation.
+
+This separation prevents the CLI from calling MCP through a subprocess and prevents the MCP adapter from duplicating business rules. Both adapters call the same operations directly.
+
+The CLI never prompts. It selects JSON when stdout is not a terminal or when `--json` is present. Diagnostics and structured errors go to stderr. Exit codes are 0 for success, 1 for an operation failure, and 2 for invalid usage. `schema --json` describes all 14 commands, their authentication class, risk class, options, output contract, and environment variables.
+
+## 5. Fixed MCP surface
+
+The tool list is fixed and ordered. It is not generated from upstream data.
+
+### Discovery — no credential
+
+- **`list_models`** — Upstream model pagination and filters, with a limit of 1-100 and a non-negative offset.
+- **`get_model`** — Exact `author/slug` model lookup.
+- **`list_model_endpoints`** — Exact model endpoint list, followed by a local provider filter and a page of 1-100.
+- **`list_providers`** — Provider discovery, local filters, and a page of 1-100.
+
+### Rankings — API key
+
+- **`list_model_rankings`** — One day by default and a maximum of 50 rows. The aggregate `other` row is excluded unless requested.
+- **`list_app_rankings`** — Popular or trending apps, with a maximum of 100 rows and an offset capped at 100.
+
+### Account — management key
+
+- **`get_credits`** — Purchased, used, and calculated remaining credits.
+- **`list_activity`** — Activity filters plus a local page of 1-100.
+- **`get_analytics_schema`** — Available analytics metrics, dimensions, filters, and classifiers.
+- **`query_analytics`** — Explicit UTC range; 1-50 metrics; at most two dimensions; at most 20 filters; result and group limits capped at 10,000.
+
+### Inference — API key
+
+- **`chat_with_model`** — One paid chat call using `max_completion_tokens`.
+- **`compare_models`** — Two to eight unique paid calls, with at most three active at once.
+
+### Generation — API key
+
+- **`get_generation`** — Fetch metadata for one explicit generation ID.
+
+The one resource is `openrouter://usage`. It calls the current-key endpoint and is private, short-lived account data. The 3.0.0 surface removes the bulk `openrouter://models` and `openrouter://pricing` resources. Discovery now uses bounded tools. There are no resource templates.
+
+## 6. OpenRouter API coverage and credential boundaries
+
+OpenRouter documents separate catalog, inference-key, and management-key concerns across its [models guide](https://openrouter.ai/docs/guides/overview/models), [provider endpoint](https://openrouter.ai/docs/api/api-reference/providers/list-providers), [model rankings](https://openrouter.ai/docs/api/api-reference/datasets/get-rankings-daily), [app rankings](https://openrouter.ai/docs/api/api-reference/datasets/get-app-rankings), [credits](https://openrouter.ai/docs/api/api-reference/credits/get-credits), [activity](https://openrouter.ai/docs/api/api-reference/analytics/get-user-activity), [analytics schema](https://openrouter.ai/docs/api/api-reference/beta-analytics/get-analytics-meta), [analytics query](https://openrouter.ai/docs/api/api-reference/beta-analytics/query-analytics), and [generation metadata](https://openrouter.ai/docs/api/api-reference/generations/get-generation).
+
+**Implementation decision.** The HTTP client has three explicit authentication modes:
+
+### No credential (`none`)
+
+- **Operations:** Model list, exact model, model endpoints, and providers.
+- **Header behavior:** Never sends `Authorization`, even when a key is configured.
+
+### Inference credential (`api`)
+
+- **Operations:** Rankings, chat, comparison, generation metadata, and the usage resource.
+- **Header behavior:** Requires `OPENROUTER_API_KEY`.
+
+### Management credential (`management`)
+
+- **Operations:** Credits, activity, analytics schema, and analytics query.
+- **Header behavior:** Uses `OPENROUTER_MANAGEMENT_KEY`. It falls back to `OPENROUTER_API_KEY` only so an actual management key can be supplied in either variable.
+
+The fallback does not grant management permissions to an ordinary inference key. OpenRouter still decides the key's scope.
+
+**Local verification.** Anonymous calls succeeded for the catalog, one exact model endpoint, and providers. The current implementation therefore omits credentials from those routes by design.
+
+**Remaining limitation.** Some OpenRouter endpoint reference pages display bearer authentication for catalog endpoints even though anonymous calls worked during this dated check. Anonymous discovery is recorded here as observed behavior, not as a durable upstream guarantee. A future upstream policy change could require credentials and would make these operations fail until this policy is revised.
+
+Rankings data also carries source-attribution requirements in the OpenRouter reference. A downstream UI or report must preserve the required source attribution; returning the data through MCP does not waive it.
+
+## 7. Bounds, failure handling, and transport safety
+
+### Pagination and work limits
+
+**Implementation decision.** `list_models` passes its limit and offset to OpenRouter, so the upstream request is bounded. Endpoints, providers, and activity currently fetch the endpoint's returned array and then apply local filters and a bounded slice. Their response is bounded, but their upstream transfer is not true cursor pagination. This difference is intentional and documented rather than hidden.
+
+Comparison accepts two to eight unique model IDs. A small worker pool caps active requests at three. The operation does not automatically retry a paid call. This avoids accidental duplicate charges and unbounded fan-out.
+
+Model rankings default to the most recent completed UTC day rather than the incomplete current day. App rankings request `limit + 1` when the requested limit is below 100, then omit the extra row and return `next_offset`. At the maximum limit of 100, the upstream cap leaves no look-ahead row.
+
+Analytics requires an explicit UTC start and end. The schema caps metrics, dimensions, ordinary filters, classifier structures, rows, and group rows. These input limits reduce accidental high-cardinality queries. They do not guarantee that an allowed query is cheap or accepted by OpenRouter.
+
+### Schema drift
+
+**Implementation decision.** Zod validates known required response fields. Upstream response wrappers use permissive handling so additive vendor fields are ignored rather than treated as breakage. Known fields with incompatible types still fail validation. This is forward-tolerant for additions, not for semantic changes or removed required fields.
+
+### Cancellation and timeouts
+
+**Implementation decision.** Every upstream call composes the MCP request signal with a local `AbortController`. Client cancellation aborts the OpenRouter fetch. A configurable positive `OPENROUTER_TIMEOUT_MS` defaults to 60,000 ms. Cancellation and timeout errors are distinguished.
+
+### Errors and secrets
+
+**Implementation decision.** Error bodies are collapsed to one line and bounded to the first 1,000 characters plus an ellipsis when truncated. The error includes the HTTP status and an upstream message when present. URLs and bearer credentials are not included. Tests use sentinels to check that configured keys do not appear in surfaced errors.
+
+### HTTPS and local HTTP
+
+**Implementation decision.** `OPENROUTER_BASE_URL` must use HTTPS. Plain HTTP is allowed only for `localhost`, `127.0.0.1`, or `[::1]` test and development targets. Credentials embedded in a URL are rejected. The local MCP HTTP listener also binds only to `127.0.0.1` and validates Host and Origin.
+
+**Remaining limitation.** This is not a remote production HTTP deployment. It does not implement TLS termination, OAuth, reverse-proxy trust, multi-tenant authorization, or public ingress. Those concerns must be designed at a separate deployment boundary.
+
+## 8. Packaging and supply-chain controls
+
+**Implementation decision.** The package requires Node.js 24 or newer and declares `pnpm@12.0.0`. Runtime dependencies are pinned exactly: `@modelcontextprotocol/node@2.0.0`, `@modelcontextprotocol/server@2.0.0`, `dotenv@17.4.2`, and `zod@4.5.1`. The MCP client and all development tools are also exact pins. No `latest` or version range is used.
+
+The workspace policy sets:
+
+- a 4,320-minute minimum release age, equal to 72 hours;
+- `trustPolicy: no-downgrade`;
+- `blockExoticSubdeps: true`;
+- one allowed install-time build, `esbuild@0.28.2`.
+
+The lockfile preserves exact resolutions and integrity data. It also pins the declared pnpm package-manager dependency and its platform executables. Native Node `fetch` avoids adding Axios or an OpenRouter SDK to the new shared client.
+
+**Local verification.** The npm registry identity for `pnpm@12.0.0`, its repository, Node engine, integrity, signatures, and attestations were checked during this task. The release timestamp was 2026-08-26T15:12:06.912Z. At the UTC verification time it was about 127.6 hours old, beyond the 72-hour policy.
+
+The package `files` allowlist contains only `dist`, `docs`, `examples`, `.env.example`, and `README.md`. The final `pnpm@12.0.0 pack --dry-run` listed 18 files: the public configuration example, built JavaScript and declarations, four docs including this note, one example, `package.json`, and `README.md`. Source, tests, local `.env`, Git metadata, and unrelated workspace files were absent.
+
+**Local verification from the preceding package check.** A generated tarball was previously installed into an isolated temporary directory with the already-available pnpm 11 runtime, offline and with scripts disabled. Both Windows command shims, the CLI schema, server help, and the modern protocol surface worked. This turn did not repeat that install because the current task forbids dependency installation.
+
+**Remaining limitation.** An exact-pnpm-12 attempt to add the local Windows tarball to a temporary project did not reach package installation. pnpm parsed absolute, `file:`, and relative tarball forms as registry package names and returned a resolver error. The same exact pnpm version successfully builds and packs this repository. The blocker is recorded as a Windows local-spec parser or invocation compatibility issue, not proof that the tarball is defective. No package was published.
+
+## 9. Migration and expected breakage
+
+This is a major-version migration. The following changes are intentional:
+
+- Protocol clients must use MCP `2026-07-28`; the legacy handshake and fallback are rejected.
+- The legacy `get_model_info` name is not kept as an alias. Use `get_model`.
+- Inference inputs use `max_completion_tokens`; the `max_tokens` compatibility name is removed.
+- `openrouter://models` and `openrouter://pricing` are removed. Use `list_models`, `get_model`, and `list_model_endpoints`.
+- Usage is no longer placeholder data. `openrouter://usage` requires a valid inference API key and calls the current-key endpoint.
+- Provider, ranking, credit, activity, analytics, and generation metadata operations add new upstream dependencies and credential scopes.
+- `OPENROUTER_API_KEY` is for inference-key operations. `OPENROUTER_MANAGEMENT_KEY` is the explicit management boundary.
+- HTTP GET is not a subscription channel. Only POST `/mcp` is served.
+- The direct `openrouter-mcp` CLI is non-interactive and shares the MCP operations. Existing `openrouter-mcp-server` stdio usage remains available.
+- The package requires Node.js 24 or newer.
+
+Clients should discover tools and resources instead of assuming the old lists. Automated consumers should also update snapshots for the new output envelopes, pagination fields, generation handles, and credential-specific errors.
+
+## 10. Validation record
+
+All local commands used the existing checkout and dependency graph. No dependency was added or updated.
+
+### Repository and source review
+
+- **Full release-tree review — Pass**
+  - **Proves:** Every changed and newly added source, test, and doc file was read before this note was finalized.
+  - **Does not prove:** Correctness of unrelated future edits.
+- **Historical `git show` comparison — Pass**
+  - **Proves:** The original monolith, 2.0.0 strict transition, and current 3.0.0 changes are distinguishable.
+  - **Does not prove:** Remote branch changes after this date.
+- **Tracked `git diff --check` plus note whitespace and conflict-marker scan — Pass**
+  - **Proves:** No detected whitespace errors or merge markers in the reviewed change set.
+  - **Does not prove:** Markdown semantics or external link availability.
+
+### Build, test, and package checks
+
+- **`pnpm@12.0.0 run check` — Pass**
+  - **Proves:** Type checks, ESLint, tests, and the build pass with the declared package manager.
+  - **Does not prove:** External service credentials or deployment.
+- **Test suite — 22 total: 21 pass, 1 live-only skip, 0 fail**
+  - **Proves:** The fixed surface, cache hints, strict rejection, operations, bounds, cancellation, security checks, CLI contract, and built entry points.
+  - **Does not prove:** OpenRouter account-scoped success.
+- **Built CLI `schema --json` — Pass on host**
+  - **Proves:** CLI version 3.0.0, protocol 2026-07-28, 14 command descriptions, and the output contract load from `dist`.
+  - **Does not prove:** Every command against live OpenRouter.
+- **Built server `--help` — Pass on host**
+  - **Proves:** The packaged server entry loads and exposes stdio and HTTP options.
+  - **Does not prove:** Long-running production operation.
+- **Built stdio handshake: `dist/server.js` — Pass on host**
+  - **Proves:** The modern protocol, 13 tools, and `openrouter://usage` load from the server binary.
+  - **Does not prove:** Legacy compatibility, which is intentionally rejected.
+- **Built stdio handshake: `dist/cli.js serve` — Pass on host**
+  - **Proves:** The hybrid CLI entry reaches the same modern MCP surface.
+  - **Does not prove:** Remote HTTP ingress.
+- **`pnpm@12.0.0 pack --dry-run` — Pass, 18 files**
+  - **Proves:** This note is included, while the allowlist excludes source, tests, `.env`, and workspace material.
+  - **Does not prove:** Installability in every package manager and operating system combination.
+
+### Live contracts
+
+- **Anonymous live contract — Partial pass**
+  - **Proves:** Protocol 2026-07-28; 425 catalog models; sampled `ibm-granite/granite-4.2-8b` with one endpoint; 105 providers.
+  - **Does not prove:** Stable counts, later availability of that sample, or authenticated behavior.
+- **Inference-key live contract — Failed with HTTP 401 `User not found`**
+  - **Proves:** The failure is bounded and reported without exposing a key.
+  - **Does not prove:** Successful rankings, chat, comparison, usage, or generation metadata.
+- **Management-key live contract — Skipped because no management key was configured**
+  - **Proves:** The test respects the credential boundary.
+  - **Does not prove:** Credits, activity, analytics schema, or analytics query success.
+
+Live counts are a 2026-08-31 America/Caracas snapshot and can change at any time. The live command exits nonzero when an authenticated phase fails, even though the public discovery phase passes.
+
+## 11. Known limits and release boundary
+
+- No valid OpenRouter inference-key flow was proved end to end in this run.
+- No management-key flow was exercised.
+- No paid chat call was made, so duplicate-charge avoidance is supported by code and tests, not a live billing observation.
+- No real Claude product was used for the final handshake.
+- No public HTTP service, TLS endpoint, OAuth flow, container, or deployment was created.
+- Anonymous discovery behavior can change upstream despite the dated live success.
+- Provider, endpoint, and activity response pages are locally bounded after an upstream array fetch; they are not all true upstream cursor pages.
+- App-ranking pagination cannot infer another page when the requested limit is the upstream maximum of 100 because no look-ahead row is available.
+- Cache TTLs are hints. A client can refetch earlier, and account data can change within five seconds.
+- Additive OpenRouter response fields are tolerated, but removed or incompatible required fields still cause validation errors.
+- Exact-pnpm-12 local tarball installation on Windows remains blocked at local package-spec resolution; exact-pnpm-12 build and pack checks pass.
+- This note records local release verification. It does not claim npm publication or production deployment.
+
+The release boundary is therefore clear: the repository is locally buildable, testable, and packable as a strict stateless MCP and direct CLI implementation. Authenticated OpenRouter success, real Claude-client compatibility, cross-platform tarball installation with the declared pnpm version, and production deployment remain separate gates.

--- a/docs/MCP-2026-07-28.md
+++ b/docs/MCP-2026-07-28.md
@@ -4,6 +4,7 @@
 
 | Item | Value |
 | --- | --- |
+| Server release | `3.0.0` |
 | Protocol | `2026-07-28` |
 | Release date | July 28, 2026 |
 | TypeScript SDK | `@modelcontextprotocol/server@2.0.0` and `@modelcontextprotocol/node@2.0.0` |
@@ -30,16 +31,21 @@ The server uses two v2 SDK helpers in strict mode:
 
 - `createMcpHandler` creates a fresh MCP server for every HTTP request and receives `{ legacy: "reject" }`.
 - `serveStdio` pins one modern protocol era per stdio connection and receives `{ legacy: "reject" }`.
+- The server sets `inputRequired.legacyShim` to `false`; future multi-round tools cannot silently enter the SDK's 2025-era shim.
 - An opening `initialize` request is rejected over both transports. The server does not run the SDK's legacy stateless fallback.
 
 The modern integration test sends `tools/list` as its first request. Separate tests prove that HTTP and stdio reject legacy initialization.
 
 ## Tools and resources
 
-- `registerTool` attaches a strict Zod input schema and effect annotations to each tool.
-- Successful handlers return `structuredContent` that matches an output schema.
-- The SDK turns validation failures and upstream exceptions into MCP tool errors.
-- Resources declare private cache hints.
+- Thirteen `registerTool` calls attach strict Zod input schemas, output schemas, and effect annotations.
+- Successful handlers return `structuredContent` that matches the documented stable shape.
+- `list_models` uses OpenRouter's upstream pagination. `list_model_endpoints` adds bounded local pagination to the provider list.
+- Generation IDs are explicit cross-request handles. The server keeps no chat or generation state.
+- Provider, ranking, activity, credit, and analytics operations call official OpenRouter APIs. Browser reconnaissance does not create a runtime browser dependency.
+- `get_analytics_schema` discovers OpenRouter's evolving analytics vocabulary; `query_analytics` requires an explicit time range and bounds dimensions, filters, and rows.
+- The only data resource is `openrouter://usage`. The model and pricing bulk resources were removed.
+- Static discovery results use a public one-hour cache hint. API-key usage remains private for five seconds.
 - The server registers tools and resources in a fixed order.
 
 ## Lifecycle and cancellation
@@ -61,14 +67,26 @@ Do not expose this HTTP listener directly to the internet. A remote gateway must
 
 `stdio` does not use MCP HTTP authorization. Pass OpenRouter credentials to the server process through environment variables.
 
+The direct CLI is a second adapter over the same operation layer. Its commands do not add sessions to MCP or preserve state between invocations.
+
 ## OpenRouter compatibility
 
 - The client uses native `fetch` and passes MCP cancellation to each request.
 - `HTTP-Referer` and `X-OpenRouter-Title` carry app attribution.
-- Chat sends `max_completion_tokens`. The tool still accepts `max_tokens` as a deprecated alias.
+- Chat sends `max_completion_tokens`. Version 3.0 removed the deprecated `max_tokens` alias.
 - Key usage calls `GET /api/v1/key`.
-- Model tools call `GET /api/v1/models` and page the MCP result.
-- Model and pricing responses preserve OpenRouter's structured `pricing.overrides` tiers.
+- Model discovery calls `GET /api/v1/models` with upstream limit, offset, filters, and sort parameters.
+- Exact model lookup calls `GET /api/v1/model/{author}/{slug}`.
+- Provider inspection calls `GET /api/v1/models/{author}/{slug}/endpoints`.
+- Provider discovery calls `GET /api/v1/providers` without authentication.
+- Model and app rankings call `GET /api/v1/datasets/rankings-daily` and `GET /api/v1/datasets/app-rankings` with a regular API key.
+- Credits and endpoint activity call `GET /api/v1/credits` and `GET /api/v1/activity` with a management key.
+- Analytics discovery and queries call `GET /api/v1/analytics/meta` and `POST /api/v1/analytics/query` with a management key.
+- Chat results retain the response generation ID and resolved model.
+- Generation metadata calls `GET /api/v1/generation?id=...`.
+- Stable output schemas preserve documented `pricing.overrides` tiers and strip additive unknown vendor fields.
+- Comparisons run at most three calls concurrently and do not retry paid requests.
+- Custom base URLs require HTTPS unless their host is loopback.
 
 ## Deliberate non-goals
 
@@ -77,8 +95,9 @@ This update does not:
 - publish or deploy the repository;
 - register a remote MCP server or edit global Claude and Codex configuration;
 - add a session layer over the stateless protocol;
+- ship a browser driver, replay browser traffic, depend on cookies, or expose undocumented private endpoints;
 - add OAuth without a real issuer, resource identifier, verifier, and deployment URL;
-- make paid OpenRouter calls in tests.
+- make paid OpenRouter calls in the default release gate. `pnpm run test:live` makes one short `openrouter/free` request only when an API key is configured; management analytics checks run only when a management key is configured.
 
 ## Primary references
 
@@ -89,3 +108,11 @@ This update does not:
 - [Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
 - [Official TypeScript SDK migration guide](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/migration/support-2026-07-28.md)
 - [Claude rollout note](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude)
+- [OpenRouter MCP server](https://openrouter.ai/docs/guides/overview/mcp-server)
+- [OpenRouter models API](https://openrouter.ai/docs/api/api-reference/models/list-all-models-and-their-properties)
+- [OpenRouter model endpoints API](https://openrouter.ai/docs/api/api-reference/endpoints/list-all-endpoints-for-a-model)
+- [OpenRouter generation metadata API](https://openrouter.ai/docs/api/api-reference/generations/get-request-&-usage-metadata-for-a-generation)
+- [OpenRouter analytics schema API](https://openrouter.ai/docs/api/api-reference/analytics/get-available-analytics-metrics-and-dimensions)
+- [OpenRouter analytics query API](https://openrouter.ai/docs/api/api-reference/analytics/query-analytics-data)
+- [OpenRouter Data API](https://openrouter.ai/docs/cookbook/administration/data-api)
+- [Reverse engineering and agent-built CLIs](https://www.youtube.com/watch?v=jbkxdxJfQ60)

--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
   "name": "openrouter-mcp-server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Stateless MCP 2026-07-28 server for OpenRouter",
   "main": "dist/server.js",
+  "bin": {
+    "openrouter-mcp": "dist/cli.js",
+    "openrouter-mcp-server": "dist/server.js"
+  },
+  "files": ["dist", "docs", "examples", ".env.example", "README.md"],
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts --transport stdio",
     "dev:http": "tsx watch src/server.ts --transport http",
     "build": "tsc",
+    "cli": "tsx src/cli.ts",
     "start": "node dist/server.js",
     "start:http": "node dist/server.js --transport http",
     "test": "tsx --test tests/*.test.ts",
+    "test:live": "tsx tests/live-contract.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint src tests --ext .ts --max-warnings 0",
     "check": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run build"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,907 @@
+#!/usr/bin/env node
+
+import { config as loadEnvironment } from "dotenv";
+
+import {
+  APP_RANKING_CATEGORIES,
+  APP_RANKING_SUBCATEGORIES,
+  INPUT_MODALITIES,
+  MODEL_CATEGORIES,
+  MODEL_SORTS,
+  OUTPUT_MODALITIES,
+  OpenRouterClient,
+  openRouterAnalyticsQuerySchema,
+} from "./openrouter.js";
+import {
+  chatWithModel,
+  compareModels,
+  getAnalyticsSchema,
+  getCredits,
+  getGeneration,
+  getModel,
+  listActivity,
+  listAppRankings,
+  listModelEndpoints,
+  listModelRankings,
+  listModels,
+  listProviders,
+  queryAnalytics,
+} from "./operations.js";
+import { runServer } from "./server.js";
+
+loadEnvironment({ quiet: true });
+
+const CLI_VERSION = "3.0.0";
+const SCHEMA_VERSION = "1.0.0";
+
+type OptionKind = "boolean" | "string";
+type ParsedValue = boolean | string;
+
+interface ParsedOptions {
+  positionals: string[];
+  values: Record<string, ParsedValue>;
+}
+
+interface CommandResult {
+  command: string;
+  data: unknown;
+  nextSteps: string[];
+}
+
+class CliUsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliUsageError";
+  }
+}
+
+async function main(argumentsList: string[] = process.argv.slice(2)): Promise<void> {
+  if (argumentsList.length === 0 || argumentsList.includes("--help") || argumentsList.includes("-h")) {
+    printHelp();
+    return;
+  }
+  if (argumentsList.includes("--version") || argumentsList.includes("-v")) {
+    process.stdout.write(CLI_VERSION + "\n");
+    return;
+  }
+
+  const noun = argumentsList[0];
+  if (noun === "serve") {
+    await runServer(argumentsList.slice(1));
+    return;
+  }
+
+  const api = OpenRouterClient.fromEnvironment();
+  const result = noun === "schema"
+    ? schemaCommand(argumentsList.slice(1))
+    : await executeCommand(api, noun ?? "", argumentsList.slice(1));
+  writeSuccess(result, wantsJson(argumentsList));
+}
+
+async function executeCommand(
+  api: OpenRouterClient,
+  noun: string,
+  argumentsList: string[],
+): Promise<CommandResult> {
+  const verb = argumentsList[0];
+  const commandArguments = argumentsList.slice(1);
+
+  if (noun === "models" && verb === "list") {
+    const parsed = parseOptions(commandArguments, {
+      architecture: "string",
+      category: "string",
+      distillable: "string",
+      "input-modalities": "string",
+      json: "boolean",
+      limit: "string",
+      "max-output-price": "string",
+      "max-prompt-price": "string",
+      "min-context-length": "string",
+      "min-output-price": "string",
+      "min-prompt-price": "string",
+      "model-authors": "string",
+      offset: "string",
+      "output-modalities": "string",
+      providers: "string",
+      q: "string",
+      region: "string",
+      sort: "string",
+      "supported-parameters": "string",
+      zdr: "boolean",
+    });
+    assertNoPositionals(parsed);
+    const outputModalities = readCsv(parsed, "output-modalities");
+    const output = await listModels(api, {
+      architecture: readOptionalString(parsed, "architecture"),
+      category: readEnum(parsed, "category", MODEL_CATEGORIES),
+      distillable: readOptionalBoolean(parsed, "distillable"),
+      input_modalities: readEnumList(parsed, "input-modalities", INPUT_MODALITIES),
+      limit: readInteger(parsed, "limit", 25, 1, 100),
+      max_output_price: readOptionalNumber(parsed, "max-output-price", 0),
+      max_prompt_price: readOptionalNumber(parsed, "max-prompt-price", 0),
+      min_context_length: readOptionalInteger(parsed, "min-context-length", 1),
+      min_output_price: readOptionalNumber(parsed, "min-output-price", 0),
+      min_prompt_price: readOptionalNumber(parsed, "min-prompt-price", 0),
+      model_authors: readCsv(parsed, "model-authors"),
+      offset: readInteger(parsed, "offset", 0, 0),
+      output_modalities: outputModalities?.length === 1 && outputModalities[0] === "all"
+        ? "all"
+        : validateEnumList("output-modalities", outputModalities, OUTPUT_MODALITIES),
+      providers: readCsv(parsed, "providers"),
+      q: readOptionalString(parsed, "q"),
+      region: readEnum(parsed, "region", ["eu", "us"] as const),
+      sort: readEnum(parsed, "sort", MODEL_SORTS),
+      supported_parameters: readCsv(parsed, "supported-parameters"),
+      zdr: readBoolean(parsed, "zdr", false) ? true : undefined,
+    });
+    return commandResult("models.list", output, ["models get <author/slug>", "models endpoints <author/slug>"]);
+  }
+
+  if (noun === "models" && verb === "get") {
+    const parsed = parseOptions(commandArguments, { json: "boolean" });
+    const model = requireSinglePositional(parsed, "model ID");
+    assertModelId(model);
+    return commandResult("models.get", await getModel(api, model), ["models endpoints " + model]);
+  }
+
+  if (noun === "models" && verb === "endpoints") {
+    const parsed = parseOptions(commandArguments, {
+      json: "boolean",
+      limit: "string",
+      offset: "string",
+      provider: "string",
+    });
+    const model = requireSinglePositional(parsed, "model ID");
+    assertModelId(model);
+    const output = await listModelEndpoints(api, {
+      limit: readInteger(parsed, "limit", 25, 1, 100),
+      model,
+      offset: readInteger(parsed, "offset", 0, 0),
+      provider: readOptionalString(parsed, "provider"),
+    });
+    return commandResult("models.endpoints", output, ["chat send --model " + model + " --message <text>"]);
+  }
+
+  if (noun === "providers" && verb === "list") {
+    const parsed = parseOptions(commandArguments, {
+      datacenter: "string",
+      headquarters: "string",
+      json: "boolean",
+      limit: "string",
+      offset: "string",
+      q: "string",
+    });
+    assertNoPositionals(parsed);
+    const output = await listProviders(api, {
+      datacenter: readCountryCode(parsed, "datacenter"),
+      headquarters: readCountryCode(parsed, "headquarters"),
+      limit: readInteger(parsed, "limit", 50, 1, 100),
+      offset: readInteger(parsed, "offset", 0, 0),
+      q: readOptionalString(parsed, "q"),
+    });
+    return commandResult("providers.list", output, ["models list --providers <provider>"]);
+  }
+
+  if (noun === "rankings" && verb === "models") {
+    const parsed = parseOptions(commandArguments, {
+      "context-bucket": "string",
+      date: "string",
+      "include-other": "boolean",
+      json: "boolean",
+      limit: "string",
+      modality: "string",
+    });
+    assertNoPositionals(parsed);
+    const output = await listModelRankings(api, {
+      context_bucket: readEnum(parsed, "context-bucket", ["1K", "10K", "100K", "1M", "10M"] as const),
+      date: readDate(parsed, "date"),
+      include_other: readBoolean(parsed, "include-other", false),
+      limit: readInteger(parsed, "limit", 20, 1, 50),
+      modality: readEnum(parsed, "modality", ["text", "image", "image_output", "audio", "tool_calling"] as const),
+    });
+    return commandResult("rankings.models", output, ["models get <author/slug>"]);
+  }
+
+  if (noun === "rankings" && verb === "apps") {
+    const parsed = parseOptions(commandArguments, {
+      category: "string",
+      "end-date": "string",
+      json: "boolean",
+      limit: "string",
+      offset: "string",
+      sort: "string",
+      "start-date": "string",
+      subcategory: "string",
+    });
+    assertNoPositionals(parsed);
+    const startDate = readDate(parsed, "start-date");
+    const endDate = readDate(parsed, "end-date");
+    if (startDate && endDate && startDate > endDate) {
+      throw new CliUsageError("--start-date must not be after --end-date.");
+    }
+    const output = await listAppRankings(api, {
+      category: readEnum(parsed, "category", APP_RANKING_CATEGORIES),
+      end_date: endDate,
+      limit: readInteger(parsed, "limit", 25, 1, 100),
+      offset: readInteger(parsed, "offset", 0, 0, 100),
+      sort: readEnum(parsed, "sort", ["popular", "trending"] as const) ?? "popular",
+      start_date: startDate,
+      subcategory: readEnum(parsed, "subcategory", APP_RANKING_SUBCATEGORIES),
+    });
+    return commandResult("rankings.apps", output, ["rankings apps --sort trending"]);
+  }
+
+  if (noun === "account" && verb === "credits") {
+    const parsed = parseOptions(commandArguments, { json: "boolean" });
+    assertNoPositionals(parsed);
+    return commandResult("account.credits", await getCredits(api), ["activity list"]);
+  }
+
+  if (noun === "activity" && verb === "list") {
+    const parsed = parseOptions(commandArguments, {
+      "api-key-hash": "string",
+      date: "string",
+      "group-by": "string",
+      json: "boolean",
+      limit: "string",
+      offset: "string",
+      "user-id": "string",
+      "workspace-id": "string",
+    });
+    assertNoPositionals(parsed);
+    const apiKeyHash = readOptionalString(parsed, "api-key-hash");
+    if (apiKeyHash && !/^[A-Fa-f0-9]{64}$/.test(apiKeyHash)) {
+      throw new CliUsageError("--api-key-hash must be a 64-character SHA-256 hexadecimal string.");
+    }
+    const output = await listActivity(api, {
+      api_key_hash: apiKeyHash,
+      date: readDate(parsed, "date"),
+      group_by: readEnum(parsed, "group-by", ["workspace"] as const),
+      limit: readInteger(parsed, "limit", 50, 1, 100),
+      offset: readInteger(parsed, "offset", 0, 0),
+      user_id: readOptionalString(parsed, "user-id"),
+      workspace_id: readOptionalString(parsed, "workspace-id"),
+    });
+    return commandResult("activity.list", output, ["account credits"]);
+  }
+
+  if (noun === "analytics" && verb === "schema") {
+    const parsed = parseOptions(commandArguments, { json: "boolean" });
+    assertNoPositionals(parsed);
+    return commandResult("analytics.schema", await getAnalyticsSchema(api), [
+      "analytics query --metrics total_usage,request_count --start <UTC> --end <UTC>",
+    ]);
+  }
+
+  if (noun === "analytics" && verb === "query") {
+    const parsed = parseOptions(commandArguments, {
+      "classifier-dimensions-json": "string",
+      "classifier-filters-json": "string",
+      dimensions: "string",
+      end: "string",
+      "filters-json": "string",
+      granularity: "string",
+      "group-limit": "string",
+      json: "boolean",
+      limit: "string",
+      metrics: "string",
+      "order-by": "string",
+      "order-direction": "string",
+      start: "string",
+    });
+    assertNoPositionals(parsed);
+    const orderBy = readOptionalString(parsed, "order-by");
+    const orderDirection = readEnum(parsed, "order-direction", ["asc", "desc"] as const);
+    if (!orderBy && orderDirection) {
+      throw new CliUsageError("--order-direction requires --order-by.");
+    }
+    const candidate = {
+      classifier_dimensions: readJsonOption(parsed, "classifier-dimensions-json"),
+      classifier_filters: readJsonOption(parsed, "classifier-filters-json"),
+      dimensions: readCsv(parsed, "dimensions"),
+      filters: readJsonOption(parsed, "filters-json"),
+      granularity: readEnum(parsed, "granularity", ["minute", "hour", "day", "week", "month"] as const),
+      group_limit: readOptionalBoundedInteger(parsed, "group-limit", 1, 10_000),
+      limit: readInteger(parsed, "limit", 1_000, 1, 10_000),
+      metrics: readRequiredCsv(parsed, "metrics"),
+      order_by: orderBy ? { direction: orderDirection ?? "desc", field: orderBy } : undefined,
+      time_range: {
+        end: readRequiredString(parsed, "end"),
+        start: readRequiredString(parsed, "start"),
+      },
+    };
+    const validated = openRouterAnalyticsQuerySchema.safeParse(candidate);
+    if (!validated.success) {
+      const issue = validated.error.issues[0];
+      throw new CliUsageError("Invalid analytics query: " + (issue?.message ?? "unknown validation error"));
+    }
+    const output = await queryAnalytics(api, validated.data);
+    const nextSteps = output.metadata.truncated
+      ? ["Narrow the time range or raise --limit before treating the result as complete."]
+      : validated.data.dimensions?.includes("generation_id")
+        ? ["generations get <generation-id>"]
+        : [];
+    return commandResult("analytics.query", output, nextSteps);
+  }
+
+  if (noun === "chat" && verb === "send") {
+    const parsed = parseOptions(commandArguments, {
+      json: "boolean",
+      "max-completion-tokens": "string",
+      message: "string",
+      model: "string",
+      "system-prompt": "string",
+      temperature: "string",
+    });
+    assertNoPositionals(parsed);
+    const model = readRequiredString(parsed, "model");
+    assertModelId(model);
+    const output = await chatWithModel(api, {
+      max_completion_tokens: readInteger(parsed, "max-completion-tokens", 1_000, 1, 131_072),
+      message: readRequiredString(parsed, "message"),
+      model,
+      system_prompt: readOptionalString(parsed, "system-prompt"),
+      temperature: readNumber(parsed, "temperature", 0.7, 0, 2),
+    });
+    return commandResult("chat.send", output, ["generations get " + output.generation_id]);
+  }
+
+  if (noun === "chat" && verb === "compare") {
+    const parsed = parseOptions(commandArguments, {
+      json: "boolean",
+      "max-completion-tokens": "string",
+      message: "string",
+      models: "string",
+    });
+    assertNoPositionals(parsed);
+    const models = readCsv(parsed, "models") ?? [];
+    if (models.length < 2 || models.length > 8 || new Set(models).size !== models.length) {
+      throw new CliUsageError("--models must contain two to eight unique comma-separated model IDs.");
+    }
+    models.forEach(assertModelId);
+    const output = await compareModels(api, {
+      max_completion_tokens: readInteger(parsed, "max-completion-tokens", 500, 1, 131_072),
+      message: readRequiredString(parsed, "message"),
+      models,
+    });
+    return commandResult("chat.compare", output, ["generations get <generation-id>"]);
+  }
+
+  if (noun === "generations" && verb === "get") {
+    const parsed = parseOptions(commandArguments, { json: "boolean" });
+    const generationId = requireSinglePositional(parsed, "generation ID");
+    return commandResult("generations.get", await getGeneration(api, generationId), []);
+  }
+
+  throw new CliUsageError("Unknown command. Run openrouter-mcp --help for the command list.");
+}
+
+function schemaCommand(argumentsList: string[]): CommandResult {
+  const parsed = parseOptions(argumentsList, { json: "boolean" });
+  assertNoPositionals(parsed);
+  return commandResult(
+    "schema",
+    {
+      schema_version: SCHEMA_VERSION,
+      cli_version: CLI_VERSION,
+      mcp_protocol: "2026-07-28",
+      output_contract: {
+        json: { ok: "boolean", command: "string", data: "command result", next_steps: "string[]" },
+        mode: "JSON when stdout is piped or --json is present; human-readable text on an interactive terminal",
+        stderr: "diagnostics and structured errors only",
+      },
+      exit_codes: { success: 0, operation_failed: 1, usage_error: 2 },
+      global_options: ["--json"],
+      commands: [
+        commandSchema("models list", "list_models", "none", "read-only", "models list [options]", [
+          "--q", "--category", "--architecture", "--model-authors", "--providers", "--supported-parameters",
+          "--input-modalities", "--output-modalities", "--distillable true|false", "--zdr", "--region",
+          "--min-context-length", "--min-prompt-price", "--max-prompt-price", "--min-output-price",
+          "--max-output-price", "--sort", "--limit", "--offset",
+        ]),
+        commandSchema("models get", "get_model", "none", "read-only", "models get <author/slug>"),
+        commandSchema(
+          "models endpoints",
+          "list_model_endpoints",
+          "none",
+          "read-only",
+          "models endpoints <author/slug> [options]",
+          ["--provider", "--limit", "--offset"],
+        ),
+        commandSchema("providers list", "list_providers", "none", "read-only", "providers list [options]", [
+          "--q", "--headquarters", "--datacenter", "--limit", "--offset",
+        ]),
+        commandSchema(
+          "rankings models",
+          "list_model_rankings",
+          "api",
+          "read-only",
+          "rankings models [options]",
+          ["--date", "--modality", "--context-bucket", "--include-other", "--limit"],
+        ),
+        commandSchema(
+          "rankings apps",
+          "list_app_rankings",
+          "api",
+          "read-only",
+          "rankings apps [options]",
+          ["--start-date", "--end-date", "--category", "--subcategory", "--sort", "--limit", "--offset"],
+        ),
+        commandSchema("account credits", "get_credits", "management", "read-only", "account credits"),
+        commandSchema("activity list", "list_activity", "management", "read-only", "activity list [options]", [
+          "--date", "--api-key-hash", "--user-id", "--workspace-id", "--group-by workspace", "--limit", "--offset",
+        ]),
+        commandSchema(
+          "analytics schema",
+          "get_analytics_schema",
+          "management",
+          "read-only",
+          "analytics schema",
+        ),
+        commandSchema(
+          "analytics query",
+          "query_analytics",
+          "management",
+          "read-only",
+          "analytics query --metrics CSV --start UTC --end UTC [options]",
+          [
+            "--metrics", "--start", "--end", "--dimensions", "--granularity", "--filters-json",
+            "--classifier-dimensions-json",
+            "--classifier-filters-json", "--order-by", "--order-direction", "--group-limit", "--limit",
+          ],
+        ),
+        commandSchema("chat send", "chat_with_model", "api", "paid-call", "chat send [options]", [
+          "--model", "--message", "--system-prompt", "--max-completion-tokens", "--temperature",
+        ]),
+        commandSchema("chat compare", "compare_models", "api", "paid-call", "chat compare [options]", [
+          "--models", "--message", "--max-completion-tokens",
+        ]),
+        commandSchema(
+          "generations get",
+          "get_generation",
+          "api",
+          "read-only",
+          "generations get <generation-id>",
+        ),
+        commandSchema("serve", null, "none", "local-server", "serve [--transport stdio|http] [--port N]"),
+      ],
+      environment: {
+        OPENROUTER_API_KEY: "Inference, rankings, and generation metadata",
+        OPENROUTER_MANAGEMENT_KEY: "Credits, activity, and analytics; falls back to OPENROUTER_API_KEY",
+      },
+    },
+    ["models list", "providers list"],
+  );
+}
+
+function commandSchema(
+  command: string,
+  mcpTool: string | null,
+  auth: string,
+  risk: string,
+  usage: string,
+  options: string[] = [],
+) {
+  return { command, mcp_tool: mcpTool, auth, risk, usage, options };
+}
+
+function commandResult(command: string, data: unknown, nextSteps: string[]): CommandResult {
+  return { command, data, nextSteps };
+}
+
+function parseOptions(argumentsList: string[], specification: Readonly<Record<string, OptionKind>>): ParsedOptions {
+  const values: Record<string, ParsedValue> = {};
+  const positionals: string[] = [];
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const argument = argumentsList[index];
+    if (!argument) {
+      continue;
+    }
+    if (argument === "--") {
+      positionals.push(...argumentsList.slice(index + 1));
+      break;
+    }
+    if (!argument.startsWith("--")) {
+      positionals.push(argument);
+      continue;
+    }
+    const equals = argument.indexOf("=");
+    const name = argument.slice(2, equals < 0 ? undefined : equals);
+    const kind = specification[name];
+    if (!kind) {
+      throw new CliUsageError("Unknown option --" + name + ".");
+    }
+    if (name in values) {
+      throw new CliUsageError("Option --" + name + " may be supplied only once.");
+    }
+    if (kind === "boolean") {
+      if (equals >= 0) {
+        const raw = argument.slice(equals + 1);
+        if (raw !== "true" && raw !== "false") {
+          throw new CliUsageError("Option --" + name + " accepts only true or false.");
+        }
+        values[name] = raw === "true";
+      } else {
+        values[name] = true;
+      }
+      continue;
+    }
+    const value = equals >= 0 ? argument.slice(equals + 1) : argumentsList[++index];
+    if (!value || value.startsWith("--")) {
+      throw new CliUsageError("Option --" + name + " requires a value.");
+    }
+    values[name] = value;
+  }
+  return { positionals, values };
+}
+
+function readOptionalString(parsed: ParsedOptions, name: string): string | undefined {
+  const value = parsed.values[name];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new CliUsageError("Option --" + name + " requires a string value.");
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new CliUsageError("Option --" + name + " must not be empty.");
+  }
+  return trimmed;
+}
+
+function readRequiredString(parsed: ParsedOptions, name: string): string {
+  const value = readOptionalString(parsed, name);
+  if (!value) {
+    throw new CliUsageError("Option --" + name + " is required.");
+  }
+  return value;
+}
+
+function readBoolean(parsed: ParsedOptions, name: string, fallback: boolean): boolean {
+  const value = parsed.values[name];
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "boolean") {
+    throw new CliUsageError("Option --" + name + " must be boolean.");
+  }
+  return value;
+}
+
+function readOptionalBoolean(parsed: ParsedOptions, name: string): boolean | undefined {
+  const value = readOptionalString(parsed, name);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== "true" && value !== "false") {
+    throw new CliUsageError("Option --" + name + " accepts only true or false.");
+  }
+  return value === "true";
+}
+
+function readNumber(
+  parsed: ParsedOptions,
+  name: string,
+  fallback: number,
+  minimum: number,
+  maximum = Number.POSITIVE_INFINITY,
+): number {
+  const raw = readOptionalString(parsed, name);
+  const value = raw === undefined ? fallback : Number(raw);
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new CliUsageError("Option --" + name + " must be between " + minimum + " and " + maximum + ".");
+  }
+  return value;
+}
+
+function readOptionalNumber(parsed: ParsedOptions, name: string, minimum: number): number | undefined {
+  const raw = readOptionalString(parsed, name);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < minimum) {
+    throw new CliUsageError("Option --" + name + " must be at least " + minimum + ".");
+  }
+  return value;
+}
+
+function readInteger(
+  parsed: ParsedOptions,
+  name: string,
+  fallback: number,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  const value = readNumber(parsed, name, fallback, minimum, maximum);
+  if (!Number.isSafeInteger(value)) {
+    throw new CliUsageError("Option --" + name + " must be an integer.");
+  }
+  return value;
+}
+
+function readOptionalInteger(parsed: ParsedOptions, name: string, minimum: number): number | undefined {
+  const raw = readOptionalString(parsed, name);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new CliUsageError("Option --" + name + " must be an integer of at least " + minimum + ".");
+  }
+  return value;
+}
+
+function readOptionalBoundedInteger(
+  parsed: ParsedOptions,
+  name: string,
+  minimum: number,
+  maximum: number,
+): number | undefined {
+  if (parsed.values[name] === undefined) {
+    return undefined;
+  }
+  return readInteger(parsed, name, minimum, minimum, maximum);
+}
+
+function readCsv(parsed: ParsedOptions, name: string): string[] | undefined {
+  const value = readOptionalString(parsed, name);
+  if (!value) {
+    return undefined;
+  }
+  const items = value.split(",").map((item) => item.trim()).filter(Boolean);
+  if (items.length === 0) {
+    throw new CliUsageError("Option --" + name + " must contain at least one value.");
+  }
+  return items;
+}
+
+function readRequiredCsv(parsed: ParsedOptions, name: string): string[] {
+  const values = readCsv(parsed, name);
+  if (!values) {
+    throw new CliUsageError("Option --" + name + " is required.");
+  }
+  return values;
+}
+
+function readJsonOption(parsed: ParsedOptions, name: string): unknown {
+  const value = readOptionalString(parsed, name);
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    throw new CliUsageError("Option --" + name + " must contain valid JSON.");
+  }
+}
+
+function readEnum<const T extends readonly string[]>(
+  parsed: ParsedOptions,
+  name: string,
+  allowed: T,
+): T[number] | undefined {
+  const value = readOptionalString(parsed, name);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!allowed.includes(value)) {
+    throw new CliUsageError("Option --" + name + " must be one of: " + allowed.join(", ") + ".");
+  }
+  return value as T[number];
+}
+
+function readEnumList<const T extends readonly string[]>(
+  parsed: ParsedOptions,
+  name: string,
+  allowed: T,
+): Array<T[number]> | undefined {
+  return validateEnumList(name, readCsv(parsed, name), allowed);
+}
+
+function validateEnumList<const T extends readonly string[]>(
+  name: string,
+  values: string[] | undefined,
+  allowed: T,
+): Array<T[number]> | undefined {
+  if (!values) {
+    return undefined;
+  }
+  for (const value of values) {
+    if (!allowed.includes(value)) {
+      throw new CliUsageError("Option --" + name + " must contain only: " + allowed.join(", ") + ".");
+    }
+  }
+  return values as Array<T[number]>;
+}
+
+function readCountryCode(parsed: ParsedOptions, name: string): string | undefined {
+  const value = readOptionalString(parsed, name);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^[A-Za-z]{2}$/.test(value)) {
+    throw new CliUsageError("Option --" + name + " must be a two-letter country code.");
+  }
+  return value.toUpperCase();
+}
+
+function readDate(parsed: ParsedOptions, name: string): string | undefined {
+  const value = readOptionalString(parsed, name);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new CliUsageError("Option --" + name + " must use YYYY-MM-DD in UTC.");
+  }
+  const parsedDate = new Date(value + "T00:00:00.000Z");
+  if (Number.isNaN(parsedDate.valueOf()) || parsedDate.toISOString().slice(0, 10) !== value) {
+    throw new CliUsageError("Option --" + name + " is not a valid calendar date.");
+  }
+  return value;
+}
+
+function requireSinglePositional(parsed: ParsedOptions, label: string): string {
+  if (parsed.positionals.length !== 1 || !parsed.positionals[0]) {
+    throw new CliUsageError("Exactly one " + label + " is required.");
+  }
+  return parsed.positionals[0];
+}
+
+function assertNoPositionals(parsed: ParsedOptions): void {
+  if (parsed.positionals.length > 0) {
+    throw new CliUsageError("Unexpected positional argument: " + parsed.positionals[0]);
+  }
+}
+
+function assertModelId(model: string): void {
+  if (!/^[^\s/]+\/[^\s/]+$/.test(model)) {
+    throw new CliUsageError("Model must use the exact author/slug format.");
+  }
+}
+
+function wantsJson(argumentsList: string[]): boolean {
+  return !process.stdout.isTTY || argumentsList.some((argument) => argument === "--json" || argument === "--json=true");
+}
+
+function writeSuccess(result: CommandResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      command: result.command,
+      data: result.data,
+      next_steps: result.nextSteps,
+    }, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(formatHuman(result) + "\n");
+}
+
+function formatHuman(result: CommandResult): string {
+  const data = result.data as Record<string, unknown>;
+  if (result.command === "models.list") {
+    const models = (data.models ?? []) as Array<Record<string, unknown>>;
+    return renderTable(
+      ["MODEL", "CONTEXT", "PROMPT / 1M", "OUTPUT / 1M"],
+      models.map((model) => {
+        const pricing = model.pricing as Record<string, unknown> | undefined;
+        return [
+          String(model.id ?? ""),
+          formatInteger(model.context_length),
+          formatPerMillion(pricing?.prompt),
+          formatPerMillion(pricing?.completion),
+        ];
+      }),
+    );
+  }
+  if (result.command === "providers.list") {
+    const providers = (data.providers ?? []) as Array<Record<string, unknown>>;
+    return renderTable(
+      ["PROVIDER", "HEADQUARTERS", "DATACENTERS"],
+      providers.map((provider) => [
+        String(provider.slug ?? ""),
+        String(provider.headquarters ?? "-"),
+        Array.isArray(provider.datacenters) ? provider.datacenters.join(",") : "-",
+      ]),
+    );
+  }
+  if (result.command === "rankings.models") {
+    const rankings = (data.rankings ?? []) as Array<Record<string, unknown>>;
+    return renderTable(
+      ["RANK", "MODEL", "TOKENS"],
+      rankings.map((item) => [String(item.rank ?? ""), String(item.model_permaslug ?? ""), String(item.total_tokens ?? "")]),
+    ) + "\n\n" + String(data.attribution ?? "");
+  }
+  if (result.command === "rankings.apps") {
+    const apps = (data.apps ?? []) as Array<Record<string, unknown>>;
+    return renderTable(
+      ["RANK", "APP", "REQUESTS", "TOKENS"],
+      apps.map((app) => [
+        String(app.rank ?? ""),
+        String(app.app_name ?? ""),
+        formatInteger(app.total_requests),
+        String(app.total_tokens ?? ""),
+      ]),
+    ) + "\n\n" + String(data.attribution ?? "");
+  }
+  if (result.command === "account.credits") {
+    return [
+      "Purchased: $" + formatDecimal(data.total_credits),
+      "Used:      $" + formatDecimal(data.total_usage),
+      "Remaining: $" + formatDecimal(data.remaining_credits),
+    ].join("\n");
+  }
+  if (result.command === "chat.send") {
+    return String(data.response ?? "") + "\n\nGeneration: " + String(data.generation_id ?? "");
+  }
+  return JSON.stringify(result.data, null, 2);
+}
+
+function renderTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index]?.length ?? 0)),
+  );
+  const renderRow = (row: string[]): string => row.map((cell, index) => cell.padEnd(widths[index] ?? 0)).join("  ").trimEnd();
+  return [renderRow(headers), renderRow(widths.map((width) => "-".repeat(width))), ...rows.map(renderRow)].join("\n");
+}
+
+function formatInteger(value: unknown): string {
+  return typeof value === "number" ? new Intl.NumberFormat("en-US").format(value) : "-";
+}
+
+function formatPerMillion(value: unknown): string {
+  if (typeof value !== "string") {
+    return "-";
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? "$" + formatDecimal(numeric * 1_000_000) : "-";
+}
+
+function formatDecimal(value: unknown): string {
+  return typeof value === "number" ? value.toLocaleString("en-US", { maximumFractionDigits: 6 }) : "-";
+}
+
+function printHelp(): void {
+  process.stdout.write([
+    "Usage: openrouter-mcp <noun> <verb> [arguments] [options]",
+    "",
+    "Discovery",
+    "  models list                         Search and page models",
+    "  models get <author/slug>            Get one model",
+    "  models endpoints <author/slug>      List serving endpoints",
+    "  providers list                      List providers and data locations",
+    "  rankings models                     List model usage rankings",
+    "  rankings apps                       List public app rankings",
+    "",
+    "Account",
+    "  account credits                     Get purchased, used, and remaining credits",
+    "  activity list                       List endpoint-level account activity",
+    "  analytics schema                    Discover current analytics fields",
+    "  analytics query                     Query Activity Explore aggregates",
+    "",
+    "Inference",
+    "  chat send --model ID --message TEXT Send one paid inference call",
+    "  chat compare --models A,B --message TEXT",
+    "  generations get <generation-id>     Get exact cost and routing metadata",
+    "",
+    "Runtime",
+    "  schema                              Print the agent-readable command contract",
+    "  serve --transport stdio|http        Run strict stateless MCP 2026-07-28",
+    "",
+    "Use --json for structured output. JSON is automatic when stdout is not a TTY.",
+    "Secrets come only from OPENROUTER_API_KEY and OPENROUTER_MANAGEMENT_KEY.",
+    "",
+  ].join("\n"));
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error instanceof CliUsageError ? "usage_error" : "operation_failed";
+  if (wantsJson(process.argv.slice(2))) {
+    process.stderr.write(JSON.stringify({ ok: false, error: { code, message } }, null, 2) + "\n");
+  } else {
+    process.stderr.write("Error: " + message + "\n");
+  }
+  process.exitCode = error instanceof CliUsageError ? 2 : 1;
+});

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,117 +2,396 @@ import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
 import * as z from "zod/v4";
 
 import {
+  APP_RANKING_CATEGORIES,
+  APP_RANKING_SUBCATEGORIES,
+  INPUT_MODALITIES,
+  MODEL_CATEGORIES,
+  MODEL_SORTS,
+  OUTPUT_MODALITIES,
   OpenRouterClient,
+  openRouterActivityItemSchema,
+  openRouterAnalyticsMetaSchema,
+  openRouterAnalyticsQueryResultSchema,
+  openRouterAnalyticsQuerySchema,
+  openRouterAppRankingItemSchema,
+  openRouterCreditsSchema,
+  openRouterEndpointSchema,
+  openRouterGenerationSchema,
   openRouterModelSchema,
+  openRouterModelRankingItemSchema,
   openRouterPricingSchema,
+  openRouterProviderSchema,
+  openRouterRankingsMetaSchema,
   type OpenRouterApi,
-  type OpenRouterModel,
 } from "./openrouter.js";
+import {
+  chatWithModel,
+  compareModels,
+  getAnalyticsSchema,
+  getCredits,
+  getGeneration,
+  getModel,
+  listActivity,
+  listAppRankings,
+  listModelEndpoints,
+  listModelRankings,
+  listModels,
+  listProviders,
+  queryAnalytics,
+} from "./operations.js";
 
 export const SERVER_NAME = "openrouter-mcp-server";
-export const SERVER_VERSION = "2.0.0";
+export const SERVER_VERSION = "3.0.0";
 
+const STATIC_DISCOVERY_CACHE_MS = 3_600_000;
 const usageSchema = z.record(z.string(), z.unknown()).nullable();
 
+const modelIdSchema = z
+  .string()
+  .trim()
+  .regex(/^[^\s/]+\/[^\s/]+$/, "Model must use the exact author/slug format.");
+
+const stringFilterListSchema = z
+  .array(z.string().trim().min(1).max(100))
+  .min(1)
+  .max(20);
+
 const modelSummarySchema = z.object({
-  id: z.string(),
-  name: z.string().optional(),
-  description: z.string().optional(),
+  agentic_index: z.number().nullable().optional(),
+  canonical_slug: z.string().optional(),
+  coding_index: z.number().nullable().optional(),
   context_length: z.number().int().nonnegative().optional(),
+  created: z.number().int().nonnegative().optional(),
+  id: z.string(),
+  input_modalities: z.array(z.string()).optional(),
+  intelligence_index: z.number().nullable().optional(),
+  max_completion_tokens: z.number().int().nonnegative().nullable().optional(),
+  name: z.string().optional(),
+  output_modalities: z.array(z.string()).optional(),
   pricing: openRouterPricingSchema.optional(),
 });
 
 const listModelsInputSchema = z
   .object({
-    q: z.string().trim().min(1).optional().describe("Optional text query passed to OpenRouter."),
+    architecture: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Architecture or model family, such as GPT, Claude, Gemini, or Llama."),
+    category: z.enum(MODEL_CATEGORIES).optional().describe("OpenRouter use-case category."),
+    distillable: z.boolean().optional().describe("Include or exclude models that support distillation."),
+    input_modalities: z
+      .array(z.enum(INPUT_MODALITIES))
+      .min(1)
+      .max(INPUT_MODALITIES.length)
+      .optional()
+      .describe("Required input modalities."),
     limit: z.number().int().min(1).max(100).default(25).describe("Maximum models to return, from 1 to 100."),
-    offset: z.number().int().min(0).default(0).describe("Zero-based offset into the matching models."),
+    max_agentic_index: z.number().nonnegative().optional(),
+    max_age_days: z.number().int().nonnegative().optional(),
+    max_coding_index: z.number().nonnegative().optional(),
+    max_intelligence_index: z.number().nonnegative().optional(),
+    max_output_price: z.number().nonnegative().optional().describe("Maximum output price in USD per million tokens."),
+    max_prompt_price: z.number().nonnegative().optional().describe("Maximum prompt price in USD per million tokens."),
+    max_tool_success_rate: z.number().min(0).max(1).optional(),
+    min_agentic_index: z.number().nonnegative().optional(),
+    min_age_days: z.number().int().nonnegative().optional(),
+    min_coding_index: z.number().nonnegative().optional(),
+    min_context_length: z.number().int().min(1).optional().describe("Minimum context length in tokens."),
+    min_intelligence_index: z.number().nonnegative().optional(),
+    min_output_price: z.number().nonnegative().optional().describe("Minimum output price in USD per million tokens."),
+    min_prompt_price: z.number().nonnegative().optional().describe("Minimum prompt price in USD per million tokens."),
+    min_tool_success_rate: z.number().min(0).max(1).optional(),
+    model_authors: stringFilterListSchema.optional().describe("Model authors, such as openai or anthropic."),
+    offset: z.number().int().min(0).default(0).describe("Number of matching models to skip upstream."),
+    output_modalities: z
+      .union([
+        z.literal("all"),
+        z.array(z.enum(OUTPUT_MODALITIES)).min(1).max(OUTPUT_MODALITIES.length),
+      ])
+      .optional()
+      .describe("Required output modalities, or 'all' to disable OpenRouter's text default."),
+    providers: stringFilterListSchema.optional().describe("Hosting providers to require."),
+    q: z.string().trim().min(1).max(200).optional().describe("Free-text model name or slug search."),
+    region: z.enum(["eu", "us"]).optional().describe("Require endpoints in this data region."),
+    sort: z.enum(MODEL_SORTS).optional().describe("Server-side OpenRouter result ordering."),
+    supported_parameters: stringFilterListSchema.optional().describe("Required inference parameters."),
+    zdr: z.literal(true).optional().describe("Require at least one zero-data-retention endpoint."),
+  })
+  .strict()
+  .refine((value) => validRange(value.min_prompt_price, value.max_prompt_price), {
+    message: "min_prompt_price must not exceed max_prompt_price.",
+    path: ["max_prompt_price"],
+  })
+  .refine((value) => validRange(value.min_output_price, value.max_output_price), {
+    message: "min_output_price must not exceed max_output_price.",
+    path: ["max_output_price"],
+  })
+  .refine((value) => validRange(value.min_age_days, value.max_age_days), {
+    message: "min_age_days must not exceed max_age_days.",
+    path: ["max_age_days"],
+  })
+  .refine((value) => validRange(value.min_intelligence_index, value.max_intelligence_index), {
+    message: "min_intelligence_index must not exceed max_intelligence_index.",
+    path: ["max_intelligence_index"],
+  })
+  .refine((value) => validRange(value.min_coding_index, value.max_coding_index), {
+    message: "min_coding_index must not exceed max_coding_index.",
+    path: ["max_coding_index"],
+  })
+  .refine((value) => validRange(value.min_agentic_index, value.max_agentic_index), {
+    message: "min_agentic_index must not exceed max_agentic_index.",
+    path: ["max_agentic_index"],
+  })
+  .refine((value) => validRange(value.min_tool_success_rate, value.max_tool_success_rate), {
+    message: "min_tool_success_rate must not exceed max_tool_success_rate.",
+    path: ["max_tool_success_rate"],
+  });
+
+const listModelsOutputSchema = z.object({
+  has_more: z.boolean(),
+  models: z.array(modelSummarySchema),
+  next_offset: z.number().int().nonnegative().nullable(),
+  offset: z.number().int().nonnegative(),
+  returned: z.number().int().nonnegative(),
+  total_count: z.number().int().nonnegative(),
+});
+
+const getModelInputSchema = z
+  .object({
+    model: modelIdSchema.describe("Exact OpenRouter model ID, including optional variant suffix."),
   })
   .strict();
 
-const listModelsOutputSchema = z.object({
-  models: z.array(modelSummarySchema),
-  total_available: z.number().int().nonnegative(),
-  returned: z.number().int().nonnegative(),
-  offset: z.number().int().nonnegative(),
+const getModelOutputSchema = z.object({
+  model: openRouterModelSchema,
+});
+
+const listModelEndpointsInputSchema = z
+  .object({
+    limit: z.number().int().min(1).max(100).default(25),
+    model: modelIdSchema.describe("Exact OpenRouter model ID."),
+    offset: z.number().int().min(0).default(0),
+    provider: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Optional case-insensitive provider name or endpoint tag filter."),
+  })
+  .strict();
+
+const listModelEndpointsOutputSchema = z.object({
+  endpoints: z.array(openRouterEndpointSchema),
+  has_more: z.boolean(),
+  model: z.object({
+    id: z.string(),
+    name: z.string().optional(),
+  }),
   next_offset: z.number().int().nonnegative().nullable(),
+  offset: z.number().int().nonnegative(),
+  returned: z.number().int().nonnegative(),
+  total_count: z.number().int().nonnegative(),
 });
 
 const chatInputSchema = z
   .object({
-    model: z.string().trim().min(1).describe("Exact OpenRouter model ID."),
-    message: z.string().min(1).describe("User message to send to the model."),
     max_completion_tokens: z
       .number()
       .int()
       .min(1)
       .max(131_072)
-      .optional()
-      .describe("Maximum generated tokens. Preferred over the deprecated max_tokens alias."),
-    max_tokens: z
-      .number()
-      .int()
-      .min(1)
-      .max(131_072)
-      .optional()
-      .describe("Deprecated compatibility alias for max_completion_tokens."),
+      .default(1_000)
+      .describe("Maximum generated tokens."),
+    message: z.string().min(1).max(1_000_000).describe("User message to send to the model."),
+    model: modelIdSchema.describe("Exact OpenRouter model ID."),
+    system_prompt: z.string().min(1).max(100_000).optional(),
     temperature: z.number().min(0).max(2).default(0.7),
-    system_prompt: z.string().min(1).optional(),
   })
   .strict();
 
 const chatOutputSchema = z.object({
-  model: z.string(),
+  generation_id: z.string(),
+  requested_model: z.string(),
+  resolved_model: z.string().nullable(),
   response: z.string(),
   usage: usageSchema,
 });
 
 const compareInputSchema = z
   .object({
+    max_completion_tokens: z.number().int().min(1).max(131_072).default(500),
+    message: z.string().min(1).max(1_000_000),
     models: z
-      .array(z.string().trim().min(1))
+      .array(modelIdSchema)
       .min(2)
       .max(8)
-      .describe("Two to eight exact OpenRouter model IDs."),
-    message: z.string().min(1),
-    max_completion_tokens: z.number().int().min(1).max(131_072).optional(),
-    max_tokens: z
-      .number()
-      .int()
-      .min(1)
-      .max(131_072)
-      .optional()
-      .describe("Deprecated compatibility alias for max_completion_tokens."),
+      .refine((models) => new Set(models).size === models.length, "Model IDs must be unique."),
   })
   .strict();
 
 const comparisonResultSchema = z.object({
-  model: z.string(),
-  success: z.boolean(),
-  response: z.string().optional(),
-  usage: usageSchema.optional(),
   error: z.string().optional(),
+  generation_id: z.string().optional(),
+  requested_model: z.string(),
+  resolved_model: z.string().nullable().optional(),
+  response: z.string().optional(),
+  success: z.boolean(),
+  usage: usageSchema.optional(),
 });
 
 const compareOutputSchema = z.object({
   results: z.array(comparisonResultSchema),
 });
 
-const getModelInfoInputSchema = z
+const getGenerationInputSchema = z
   .object({
-    model: z.string().trim().min(1).describe("Exact OpenRouter model ID."),
+    generation_id: z.string().trim().min(1).max(200).describe("Generation ID returned by a paid OpenRouter call."),
   })
   .strict();
 
-const getModelInfoOutputSchema = z.object({
-  model: openRouterModelSchema,
+const getGenerationOutputSchema = z.object({
+  generation: openRouterGenerationSchema,
+});
+
+const isoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD in UTC.");
+
+const countryCodeSchema = z
+  .string()
+  .trim()
+  .regex(/^[A-Za-z]{2}$/, "Country code must contain exactly two letters.")
+  .transform((value) => value.toUpperCase());
+
+const listProvidersInputSchema = z
+  .object({
+    datacenter: countryCodeSchema.optional().describe("Require a provider datacenter in this country."),
+    headquarters: countryCodeSchema.optional().describe("Require provider headquarters in this country."),
+    limit: z.number().int().min(1).max(100).default(50),
+    offset: z.number().int().min(0).default(0),
+    q: z.string().trim().min(1).max(100).optional().describe("Provider name or slug search."),
+  })
+  .strict();
+
+const listProvidersOutputSchema = z.object({
+  has_more: z.boolean(),
+  next_offset: z.number().int().nonnegative().nullable(),
+  offset: z.number().int().nonnegative(),
+  providers: z.array(openRouterProviderSchema),
+  returned: z.number().int().nonnegative(),
+  total_count: z.number().int().nonnegative(),
+});
+
+const getCreditsInputSchema = z.object({}).strict();
+const getCreditsOutputSchema = openRouterCreditsSchema.extend({
+  remaining_credits: z.number().nonnegative(),
+});
+
+const listActivityInputSchema = z
+  .object({
+    api_key_hash: z
+      .string()
+      .trim()
+      .regex(/^[A-Fa-f0-9]{64}$/, "API key hash must be a 64-character SHA-256 hexadecimal string.")
+      .optional(),
+    date: isoDateSchema.optional().describe("UTC activity date; defaults to the last completed UTC day."),
+    group_by: z.literal("workspace").optional(),
+    limit: z.number().int().min(1).max(100).default(50),
+    offset: z.number().int().min(0).default(0),
+    user_id: z.string().trim().min(1).max(200).optional(),
+    workspace_id: z.uuid().optional(),
+  })
+  .strict();
+
+const listActivityOutputSchema = z.object({
+  activity: z.array(openRouterActivityItemSchema),
+  date: isoDateSchema,
+  has_more: z.boolean(),
+  next_offset: z.number().int().nonnegative().nullable(),
+  offset: z.number().int().nonnegative(),
+  returned: z.number().int().nonnegative(),
+  total_count: z.number().int().nonnegative(),
+});
+
+const getAnalyticsSchemaInputSchema = z.object({}).strict();
+const getAnalyticsSchemaOutputSchema = z.object({ schema: openRouterAnalyticsMetaSchema });
+
+const listModelRankingsInputSchema = z
+  .object({
+    context_bucket: z.enum(["1K", "10K", "100K", "1M", "10M"]).optional(),
+    date: isoDateSchema.optional().describe("UTC ranking date; defaults to the last completed UTC day."),
+    include_other: z.boolean().default(false).describe("Include OpenRouter's aggregated long-tail row."),
+    limit: z.number().int().min(1).max(50).default(20),
+    modality: z.enum(["text", "image", "image_output", "audio", "tool_calling"]).optional(),
+  })
+  .strict();
+
+const listModelRankingsOutputSchema = z.object({
+  attribution: z.string(),
+  date: isoDateSchema,
+  meta: openRouterRankingsMetaSchema,
+  rankings: z.array(openRouterModelRankingItemSchema.extend({ rank: z.number().int().positive() })),
+  returned: z.number().int().nonnegative(),
+});
+
+const listAppRankingsInputSchema = z
+  .object({
+    category: z.enum(APP_RANKING_CATEGORIES).optional(),
+    end_date: isoDateSchema.optional(),
+    limit: z.number().int().min(1).max(100).default(25),
+    offset: z.number().int().min(0).max(100).default(0),
+    sort: z.enum(["popular", "trending"]).default("popular"),
+    start_date: isoDateSchema.optional(),
+    subcategory: z.enum(APP_RANKING_SUBCATEGORIES).optional(),
+  })
+  .strict()
+  .refine((value) => !value.start_date || !value.end_date || value.start_date <= value.end_date, {
+    message: "start_date must not be after end_date.",
+    path: ["end_date"],
+  });
+
+const listAppRankingsOutputSchema = z.object({
+  apps: z.array(openRouterAppRankingItemSchema),
+  attribution: z.string(),
+  has_more: z.boolean(),
+  meta: openRouterRankingsMetaSchema,
+  next_offset: z.number().int().nonnegative().nullable(),
+  offset: z.number().int().nonnegative(),
+  returned: z.number().int().nonnegative(),
 });
 
 export function createOpenRouterMcpServer(api: OpenRouterApi = OpenRouterClient.fromEnvironment()): McpServer {
-  const server = new McpServer({
-    name: SERVER_NAME,
-    version: SERVER_VERSION,
-  });
+  const publicDiscoveryCache = {
+    cacheScope: "public" as const,
+    ttlMs: STATIC_DISCOVERY_CACHE_MS,
+  };
+  const server = new McpServer(
+    {
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
+    },
+    {
+      cacheHints: {
+        "resources/list": publicDiscoveryCache,
+        "resources/templates/list": publicDiscoveryCache,
+        "server/discover": publicDiscoveryCache,
+        "tools/list": publicDiscoveryCache,
+      },
+      inputRequired: {
+        legacyShim: false,
+      },
+      instructions:
+        "Use list_models, get_model, list_model_endpoints, list_providers, and list_model_rankings for live selection data. " +
+        "Use list_app_rankings for the public app marketplace. Account tools require a management key. Call " +
+        "get_analytics_schema before query_analytics because OpenRouter adds metrics and dimensions over time. " +
+        "chat_with_model and compare_models can spend credits. Preserve generation_id values and use get_generation " +
+        "for exact provider, token, latency, and cost metadata.",
+    },
+  );
 
   registerResources(server, api);
   registerTools(server, api);
@@ -124,57 +403,6 @@ export function createOpenRouterMcpHandler(api: OpenRouterApi = OpenRouterClient
 }
 
 function registerResources(server: McpServer, api: OpenRouterApi): void {
-  server.registerResource(
-    "available-models",
-    "openrouter://models",
-    {
-      title: "Available OpenRouter models",
-      description: "Current OpenRouter model metadata, including context limits and pricing.",
-      mimeType: "application/json",
-      cacheHint: { ttlMs: 60_000, cacheScope: "private" },
-    },
-    async (uri, ctx) => {
-      const models = await api.listModels({}, ctx.mcpReq.signal);
-      return {
-        contents: [
-          {
-            uri: uri.href,
-            mimeType: "application/json",
-            text: JSON.stringify({ data: models }, null, 2),
-          },
-        ],
-      };
-    },
-  );
-
-  server.registerResource(
-    "model-pricing",
-    "openrouter://pricing",
-    {
-      title: "OpenRouter model pricing",
-      description: "Current pricing fields for available OpenRouter models.",
-      mimeType: "application/json",
-      cacheHint: { ttlMs: 60_000, cacheScope: "private" },
-    },
-    async (uri, ctx) => {
-      const models = await api.listModels({}, ctx.mcpReq.signal);
-      const pricing = models.map((model) => ({
-        id: model.id,
-        name: model.name,
-        pricing: model.pricing,
-      }));
-      return {
-        contents: [
-          {
-            uri: uri.href,
-            mimeType: "application/json",
-            text: JSON.stringify({ data: pricing }, null, 2),
-          },
-        ],
-      };
-    },
-  );
-
   server.registerResource(
     "key-usage",
     "openrouter://usage",
@@ -204,62 +432,149 @@ function registerTools(server: McpServer, api: OpenRouterApi): void {
     "list_models",
     {
       title: "List OpenRouter models",
-      description: "Search and page through currently available OpenRouter models.",
+      description:
+        "Search, filter, sort, and page OpenRouter's live model catalog. Returns compact selection metadata; use get_model for full details.",
       inputSchema: listModelsInputSchema,
       outputSchema: listModelsOutputSchema,
-      annotations: {
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: true,
-      },
+      annotations: readOnlyAnnotations(),
     },
-    async ({ q, limit, offset }, ctx) => {
-      const models = await api.listModels({ q }, ctx.mcpReq.signal);
-      const page = models.slice(offset, offset + limit).map(summarizeModel);
-      const nextOffset = offset + page.length < models.length ? offset + page.length : null;
-      const output = {
-        models: page,
-        total_available: models.length,
-        returned: page.length,
-        offset,
-        next_offset: nextOffset,
-      };
-      return toolResult(output);
+    async (input, ctx) => {
+      return toolResult(await listModels(api, input, ctx.mcpReq.signal));
     },
+  );
+
+  server.registerTool(
+    "get_model",
+    {
+      title: "Get an OpenRouter model",
+      description: "Return current full metadata for one exact OpenRouter author/slug, variant, or alias.",
+      inputSchema: getModelInputSchema,
+      outputSchema: getModelOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async ({ model: modelId }, ctx) => {
+      return toolResult(await getModel(api, modelId, ctx.mcpReq.signal));
+    },
+  );
+
+  server.registerTool(
+    "list_model_endpoints",
+    {
+      title: "List OpenRouter model endpoints",
+      description:
+        "List the providers serving one model, including price, context, uptime, latency, throughput, and supported parameters.",
+      inputSchema: listModelEndpointsInputSchema,
+      outputSchema: listModelEndpointsOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (input, ctx) => {
+      return toolResult(await listModelEndpoints(api, input, ctx.mcpReq.signal));
+    },
+  );
+
+  server.registerTool(
+    "list_providers",
+    {
+      title: "List OpenRouter providers",
+      description:
+        "List and filter OpenRouter providers with headquarters, datacenter, privacy-policy, terms, and status-page metadata.",
+      inputSchema: listProvidersInputSchema,
+      outputSchema: listProvidersOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (input, ctx) => toolResult(await listProviders(api, input, ctx.mcpReq.signal)),
+  );
+
+  server.registerTool(
+    "list_model_rankings",
+    {
+      title: "List OpenRouter model rankings",
+      description:
+        "Return the bounded public model-usage ranking for one completed UTC day, matching the OpenRouter rankings browser view.",
+      inputSchema: listModelRankingsInputSchema,
+      outputSchema: listModelRankingsOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (input, ctx) => toolResult(await listModelRankings(api, input, ctx.mcpReq.signal)),
+  );
+
+  server.registerTool(
+    "list_app_rankings",
+    {
+      title: "List OpenRouter app rankings",
+      description:
+        "Return popular or trending public OpenRouter apps for a bounded date window, matching the browser marketplace.",
+      inputSchema: listAppRankingsInputSchema,
+      outputSchema: listAppRankingsOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (input, ctx) => toolResult(await listAppRankings(api, input, ctx.mcpReq.signal)),
+  );
+
+  server.registerTool(
+    "get_credits",
+    {
+      title: "Get OpenRouter credits",
+      description:
+        "Return purchased, used, and remaining OpenRouter credits. Requires OPENROUTER_MANAGEMENT_KEY or a management key in OPENROUTER_API_KEY.",
+      inputSchema: getCreditsInputSchema,
+      outputSchema: getCreditsOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (_input, ctx) => toolResult(await getCredits(api, ctx.mcpReq.signal)),
+  );
+
+  server.registerTool(
+    "list_activity",
+    {
+      title: "List OpenRouter account activity",
+      description:
+        "List bounded endpoint-level usage for one UTC day with optional key, user, or workspace filters. Requires a management key.",
+      inputSchema: listActivityInputSchema,
+      outputSchema: listActivityOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (input, ctx) => toolResult(await listActivity(api, input, ctx.mcpReq.signal)),
+  );
+
+  server.registerTool(
+    "get_analytics_schema",
+    {
+      title: "Get OpenRouter analytics schema",
+      description:
+        "Discover the current metrics, dimensions, filter operators, and time granularities accepted by query_analytics. Requires a management key.",
+      inputSchema: getAnalyticsSchemaInputSchema,
+      outputSchema: getAnalyticsSchemaOutputSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (_input, ctx) => toolResult(await getAnalyticsSchema(api, ctx.mcpReq.signal)),
+  );
+
+  server.registerTool(
+    "query_analytics",
+    {
+      title: "Query OpenRouter analytics",
+      description:
+        "Run a bounded, explicit-time-range analytics query over the same aggregates used by OpenRouter's Activity Explore browser view. Requires a management key; call get_analytics_schema first and check metadata.truncated before drawing conclusions.",
+      inputSchema: openRouterAnalyticsQuerySchema,
+      outputSchema: openRouterAnalyticsQueryResultSchema,
+      annotations: readOnlyAnnotations(),
+    },
+    async (input, ctx) => toolResult(await queryAnalytics(api, input, ctx.mcpReq.signal)),
   );
 
   server.registerTool(
     "chat_with_model",
     {
       title: "Chat with an OpenRouter model",
-      description: "Generate one model response through OpenRouter. This can consume paid API credits.",
+      description:
+        "Generate one response through OpenRouter. This can consume API credits and is not retried automatically.",
       inputSchema: chatInputSchema,
       outputSchema: chatOutputSchema,
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: false,
-        openWorldHint: true,
-      },
+      annotations: paidCallAnnotations(),
     },
     async (input, ctx) => {
-      const result = await api.createChatCompletion(
-        {
-          model: input.model,
-          message: input.message,
-          maxCompletionTokens: input.max_completion_tokens ?? input.max_tokens ?? 1_000,
-          temperature: input.temperature,
-          systemPrompt: input.system_prompt,
-        },
-        ctx.mcpReq.signal,
-      );
-      const output = {
-        model: input.model,
-        response: normalizeContent(result.content),
-        usage: result.usage ?? null,
-      };
-      return toolResult(output);
+      return toolResult(await chatWithModel(api, input, ctx.mcpReq.signal));
     },
   );
 
@@ -267,85 +582,53 @@ function registerTools(server: McpServer, api: OpenRouterApi): void {
     "compare_models",
     {
       title: "Compare OpenRouter models",
-      description: "Generate the same prompt with two to eight models. Each model call can consume paid API credits.",
+      description:
+        "Generate the same prompt with two to eight models. Each model call can consume credits; at most three run concurrently and none are retried automatically.",
       inputSchema: compareInputSchema,
       outputSchema: compareOutputSchema,
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: false,
-        openWorldHint: true,
-      },
+      annotations: paidCallAnnotations(),
     },
     async (input, ctx) => {
-      const maxCompletionTokens = input.max_completion_tokens ?? input.max_tokens ?? 500;
-      const results = await Promise.all(
-        input.models.map(async (model) => {
-          try {
-            const result = await api.createChatCompletion(
-              {
-                model,
-                message: input.message,
-                maxCompletionTokens,
-                temperature: 0.7,
-              },
-              ctx.mcpReq.signal,
-            );
-            return {
-              model,
-              success: true,
-              response: normalizeContent(result.content),
-              usage: result.usage ?? null,
-            };
-          } catch (error) {
-            if (ctx.mcpReq.signal.aborted) {
-              throw error;
-            }
-            return {
-              model,
-              success: false,
-              error: toErrorMessage(error),
-            };
-          }
-        }),
-      );
-      return toolResult({ results });
+      return toolResult(await compareModels(api, input, ctx.mcpReq.signal));
     },
   );
 
   server.registerTool(
-    "get_model_info",
+    "get_generation",
     {
-      title: "Get OpenRouter model information",
-      description: "Return current metadata for one exact OpenRouter model ID.",
-      inputSchema: getModelInfoInputSchema,
-      outputSchema: getModelInfoOutputSchema,
-      annotations: {
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: true,
-      },
+      title: "Get OpenRouter generation metadata",
+      description:
+        "Resolve a generation ID into exact model, provider, token, latency, and cost metadata without server-side session state.",
+      inputSchema: getGenerationInputSchema,
+      outputSchema: getGenerationOutputSchema,
+      annotations: readOnlyAnnotations(),
     },
-    async ({ model: modelId }, ctx) => {
-      const matches = await api.listModels({ q: modelId }, ctx.mcpReq.signal);
-      const model = matches.find((candidate) => candidate.id === modelId);
-      if (!model) {
-        throw new Error("OpenRouter model not found: " + modelId);
-      }
-      return toolResult({ model });
+    async ({ generation_id: generationId }, ctx) => {
+      return toolResult(await getGeneration(api, generationId, ctx.mcpReq.signal));
     },
   );
 }
 
-function summarizeModel(model: OpenRouterModel): z.infer<typeof modelSummarySchema> {
+function readOnlyAnnotations() {
   return {
-    id: model.id,
-    name: model.name,
-    description: model.description,
-    context_length: model.context_length,
-    pricing: model.pricing,
-  };
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  } as const;
+}
+
+function paidCallAnnotations() {
+  return {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  } as const;
+}
+
+function validRange(minimum: number | undefined, maximum: number | undefined): boolean {
+  return minimum === undefined || maximum === undefined || minimum <= maximum;
 }
 
 function toolResult<T>(output: T): {
@@ -356,16 +639,4 @@ function toolResult<T>(output: T): {
     content: [{ type: "text", text: JSON.stringify(output, null, 2) }],
     structuredContent: output,
   };
-}
-
-function normalizeContent(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  const serialized = JSON.stringify(content);
-  return serialized ?? String(content);
-}
-
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/src/openrouter.ts
+++ b/src/openrouter.ts
@@ -2,54 +2,398 @@ import * as z from "zod/v4";
 
 const priceSchema = z.string();
 
-const pricingOverrideSchema = z
-  .object({
-    audio: priceSchema.optional(),
-    completion: priceSchema.optional(),
-    input_audio_cache: priceSchema.optional(),
-    input_cache_read: priceSchema.optional(),
-    input_cache_write: priceSchema.optional(),
-    input_cache_write_1h: priceSchema.optional(),
-    min_prompt_tokens: z.number().int().nonnegative().optional(),
-    prompt: priceSchema.optional(),
-    utc_days: z.array(z.string()).optional(),
-    utc_end: z.number().int().nonnegative().optional(),
-    utc_start: z.number().int().nonnegative().optional(),
-  })
-  .strict();
+const pricingOverrideSchema = z.object({
+  audio: priceSchema.optional(),
+  completion: priceSchema.optional(),
+  input_audio_cache: priceSchema.optional(),
+  input_cache_read: priceSchema.optional(),
+  input_cache_write: priceSchema.optional(),
+  input_cache_write_1h: priceSchema.optional(),
+  min_prompt_tokens: z.number().int().nonnegative().optional(),
+  prompt: priceSchema.optional(),
+  utc_days: z.array(z.string()).optional(),
+  utc_end: z.number().int().nonnegative().optional(),
+  utc_start: z.number().int().nonnegative().optional(),
+});
 
-export const openRouterPricingSchema = z
-  .object({
-    audio: priceSchema.optional(),
-    audio_output: priceSchema.optional(),
-    completion: priceSchema.optional(),
-    image: priceSchema.optional(),
-    image_output: priceSchema.optional(),
-    input_audio_cache: priceSchema.optional(),
-    input_cache_read: priceSchema.optional(),
-    input_cache_write: priceSchema.optional(),
-    input_cache_write_1h: priceSchema.optional(),
-    internal_reasoning: priceSchema.optional(),
-    overrides: z.array(pricingOverrideSchema).optional(),
-    prompt: priceSchema.optional(),
-    request: priceSchema.optional(),
-    web_search: priceSchema.optional(),
-  })
-  .strict();
+/**
+ * Stable MCP pricing shape. Zod strips unknown upstream properties so additive
+ * OpenRouter changes do not leak into, or break, our public tool contract.
+ */
+export const openRouterPricingSchema = z.object({
+  audio: priceSchema.optional(),
+  audio_output: priceSchema.optional(),
+  completion: priceSchema.optional(),
+  discount: z.number().optional(),
+  image: priceSchema.optional(),
+  image_output: priceSchema.optional(),
+  input_audio_cache: priceSchema.optional(),
+  input_cache_read: priceSchema.optional(),
+  input_cache_write: priceSchema.optional(),
+  input_cache_write_1h: priceSchema.optional(),
+  internal_reasoning: priceSchema.optional(),
+  overrides: z.array(pricingOverrideSchema).optional(),
+  prompt: priceSchema.optional(),
+  request: priceSchema.optional(),
+  web_search: priceSchema.optional(),
+});
 
-export const openRouterModelSchema = z
+export const openRouterArchitectureSchema = z.object({
+  input_modalities: z.array(z.string()).optional(),
+  instruct_type: z.string().nullable().optional(),
+  modality: z.string().nullable().optional(),
+  output_modalities: z.array(z.string()).optional(),
+  tokenizer: z.string().nullable().optional(),
+});
+
+const artificialAnalysisSchema = z.object({
+  agentic_index: z.number().nullable().optional(),
+  coding_index: z.number().nullable().optional(),
+  intelligence_index: z.number().nullable().optional(),
+});
+
+const designArenaScoreSchema = z.object({
+  arena: z.string(),
+  category: z.string(),
+  elo: z.number(),
+  rank: z.number().int().nonnegative(),
+  win_rate: z.number(),
+});
+
+export const openRouterBenchmarksSchema = z.object({
+  artificial_analysis: artificialAnalysisSchema.nullable().optional(),
+  design_arena: z.array(designArenaScoreSchema).optional(),
+});
+
+export const openRouterReasoningSchema = z.object({
+  default_effort: z.string().nullable().optional(),
+  default_enabled: z.boolean().optional(),
+  mandatory: z.boolean().optional(),
+  supported_efforts: z.array(z.string()).optional(),
+});
+
+const topProviderSchema = z.object({
+  context_length: z.number().int().nonnegative().nullable().optional(),
+  is_moderated: z.boolean().optional(),
+  max_completion_tokens: z.number().int().nonnegative().nullable().optional(),
+});
+
+const modelLinksSchema = z.object({
+  details: z.string().optional(),
+});
+
+/** Stable model contract returned by MCP tools. Unknown vendor fields are stripped. */
+export const openRouterModelSchema = z.object({
+  architecture: openRouterArchitectureSchema.optional(),
+  benchmarks: openRouterBenchmarksSchema.optional(),
+  canonical_slug: z.string().optional(),
+  context_length: z.number().int().nonnegative().optional(),
+  created: z.number().int().nonnegative().optional(),
+  default_parameters: z.record(z.string(), z.unknown()).nullable().optional(),
+  description: z.string().optional(),
+  expiration_date: z.string().nullable().optional(),
+  hugging_face_id: z.string().nullable().optional(),
+  id: z.string(),
+  knowledge_cutoff: z.string().nullable().optional(),
+  links: modelLinksSchema.optional(),
+  name: z.string().optional(),
+  pricing: openRouterPricingSchema.optional(),
+  reasoning: openRouterReasoningSchema.optional(),
+  supported_parameters: z.array(z.string()).optional(),
+  top_provider: topProviderSchema.optional(),
+});
+
+const percentileSchema = z.object({
+  p50: z.number().optional(),
+  p75: z.number().optional(),
+  p90: z.number().optional(),
+  p99: z.number().optional(),
+});
+
+export const openRouterEndpointSchema = z.object({
+  context_length: z.number().int().nonnegative().nullable().optional(),
+  latency_last_30m: percentileSchema.nullable().optional(),
+  max_completion_tokens: z.number().int().nonnegative().nullable().optional(),
+  max_prompt_tokens: z.number().int().nonnegative().nullable().optional(),
+  model_id: z.string().optional(),
+  model_name: z.string().optional(),
+  name: z.string(),
+  pricing: openRouterPricingSchema.optional(),
+  provider_name: z.string().optional(),
+  quantization: z.string().nullable().optional(),
+  status: z.number().int().optional(),
+  supported_parameters: z.array(z.string()).optional(),
+  supports_implicit_caching: z.boolean().optional(),
+  supports_tool_choice: z.record(z.string(), z.boolean()).optional(),
+  supports_voice_cloning: z.boolean().optional(),
+  tag: z.string().optional(),
+  throughput_last_30m: percentileSchema.nullable().optional(),
+  uptime_last_1d: z.number().nullable().optional(),
+  uptime_last_30m: z.number().nullable().optional(),
+  uptime_last_5m: z.number().nullable().optional(),
+});
+
+export const openRouterModelEndpointsSchema = z.object({
+  architecture: openRouterArchitectureSchema.optional(),
+  created: z.number().int().nonnegative().optional(),
+  description: z.string().optional(),
+  endpoints: z.array(openRouterEndpointSchema),
+  id: z.string(),
+  name: z.string().optional(),
+});
+
+export const openRouterGenerationSchema = z.object({
+  cancelled: z.boolean().optional(),
+  created_at: z.string().optional(),
+  data_region: z.string().nullable().optional(),
+  finish_reason: z.string().nullable().optional(),
+  generation_time: z.number().nullable().optional(),
+  id: z.string(),
+  is_byok: z.boolean().optional(),
+  latency: z.number().nullable().optional(),
+  model: z.string().optional(),
+  native_finish_reason: z.string().nullable().optional(),
+  native_tokens_cached: z.number().int().nonnegative().nullable().optional(),
+  native_tokens_completion: z.number().int().nonnegative().nullable().optional(),
+  native_tokens_prompt: z.number().int().nonnegative().nullable().optional(),
+  native_tokens_reasoning: z.number().int().nonnegative().nullable().optional(),
+  provider_name: z.string().nullable().optional(),
+  request_id: z.string().nullable().optional(),
+  router: z.string().nullable().optional(),
+  service_tier: z.string().nullable().optional(),
+  streamed: z.boolean().optional(),
+  tokens_completion: z.number().int().nonnegative().nullable().optional(),
+  tokens_prompt: z.number().int().nonnegative().nullable().optional(),
+  total_cost: z.number().nullable().optional(),
+  upstream_inference_cost: z.number().nullable().optional(),
+});
+
+export const openRouterProviderSchema = z.object({
+  datacenters: z.array(z.string()).nullable().optional(),
+  headquarters: z.string().nullable().optional(),
+  name: z.string(),
+  privacy_policy_url: z.string().nullable(),
+  slug: z.string(),
+  status_page_url: z.string().nullable().optional(),
+  terms_of_service_url: z.string().nullable().optional(),
+});
+
+export const openRouterCreditsSchema = z.object({
+  total_credits: z.number().nonnegative(),
+  total_usage: z.number().nonnegative(),
+});
+
+export const openRouterActivityItemSchema = z.object({
+  api_key_hash: z.string().optional(),
+  byok_usage_inference: z.number().nonnegative(),
+  completion_tokens: z.number().int().nonnegative(),
+  date: z.string(),
+  endpoint_id: z.string(),
+  model: z.string(),
+  model_permaslug: z.string(),
+  prompt_tokens: z.number().int().nonnegative(),
+  provider_name: z.string(),
+  reasoning_tokens: z.number().int().nonnegative(),
+  requests: z.number().int().nonnegative(),
+  usage: z.number().nonnegative(),
+  user_id: z.string().optional(),
+  workspace_id: z.string().optional(),
+});
+
+export const openRouterRankingsMetaSchema = z.object({
+  as_of: z.string(),
+  end_date: z.string(),
+  start_date: z.string(),
+  version: z.literal("v1"),
+});
+
+export const openRouterModelRankingItemSchema = z.object({
+  date: z.string(),
+  model_permaslug: z.string(),
+  total_tokens: z.string().regex(/^\d+$/),
+});
+
+export const openRouterAppRankingItemSchema = z.object({
+  app_id: z.number().int().nonnegative(),
+  app_name: z.string(),
+  rank: z.number().int().positive(),
+  total_requests: z.number().int().nonnegative(),
+  total_tokens: z.string().regex(/^\d+$/),
+});
+
+const analyticsScalarSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+const analyticsFilterValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.array(z.union([z.string(), z.number()])).min(1).max(100),
+]);
+const utcTimestampSchema = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/,
+    "Timestamp must be ISO 8601 UTC with seconds.",
+  )
+  .refine((value) => !Number.isNaN(Date.parse(value)), "Timestamp must be a valid UTC date and time.");
+
+export const openRouterAnalyticsMetaSchema = z.object({
+  dimensions: z.array(z.object({ display_label: z.string(), name: z.string() })),
+  granularities: z.array(z.object({ display_label: z.string(), name: z.string() })),
+  metrics: z.array(z.object({
+    display_format: z.string(),
+    display_label: z.string(),
+    is_rate: z.boolean(),
+    name: z.string(),
+  })),
+  operators: z.array(z.object({ name: z.string(), value_type: z.string() })),
+});
+
+export const openRouterAnalyticsRowSchema = z.record(z.string(), analyticsScalarSchema);
+export const openRouterAnalyticsQueryMetadataSchema = z.object({
+  query_time_ms: z.number().nonnegative(),
+  row_count: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+});
+export const openRouterAnalyticsQueryResultSchema = z.object({
+  cached_at: z.number().nonnegative().optional(),
+  metadata: openRouterAnalyticsQueryMetadataSchema,
+  rows: z.array(openRouterAnalyticsRowSchema),
+  warnings: z.array(z.string()).optional(),
+});
+
+const analyticsFilterSchema = z
   .object({
-    id: z.string(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    context_length: z.number().int().nonnegative().optional(),
-    pricing: openRouterPricingSchema.optional(),
+    field: z.string().trim().min(1).max(128),
+    include_unset: z.boolean().optional(),
+    operator: z.enum(["eq", "neq", "in", "not_in", "gt", "gte", "lt", "lte"]),
+    value: analyticsFilterValueSchema,
+  })
+  .strict()
+  .superRefine((filter, context) => {
+    const expectsArray = filter.operator === "in" || filter.operator === "not_in";
+    if (expectsArray !== Array.isArray(filter.value)) {
+      context.addIssue({
+        code: "custom",
+        message: expectsArray ? "in and not_in require an array value." : "This operator requires a scalar value.",
+        path: ["value"],
+      });
+    }
+  });
+
+const classifierFilterSchema = z
+  .object({
+    field: z.string().trim().regex(/^[A-Za-z][A-Za-z0-9_]{0,63}$/),
+    operator: z.enum(["eq", "neq", "in", "not_in"]),
+    value: analyticsFilterValueSchema,
+  })
+  .strict()
+  .superRefine((filter, context) => {
+    const expectsArray = filter.operator === "in" || filter.operator === "not_in";
+    if (expectsArray !== Array.isArray(filter.value)) {
+      context.addIssue({
+        code: "custom",
+        message: expectsArray ? "in and not_in require an array value." : "eq and neq require a scalar value.",
+        path: ["value"],
+      });
+    }
+  });
+
+export const openRouterAnalyticsQuerySchema = z
+  .object({
+    classifier_dimensions: z
+      .object({
+        classifier_id: z.uuid(),
+        dimension_names: z
+          .array(z.string().trim().regex(/^[A-Za-z][A-Za-z0-9_]{0,63}$/))
+          .min(1)
+          .max(10)
+          .optional(),
+        include_nulls: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    classifier_filters: z
+      .object({
+        classifier_id: z.uuid(),
+        filters: z.array(classifierFilterSchema).min(1).max(10),
+      })
+      .strict()
+      .optional(),
+    dimensions: z.array(z.string().trim().min(1).max(128)).max(2).optional(),
+    filters: z.array(analyticsFilterSchema).max(20).optional(),
+    granularity: z.enum(["minute", "hour", "day", "week", "month"]).optional(),
+    group_limit: z.number().int().min(1).max(10_000).optional(),
+    limit: z.number().int().min(1).max(10_000).default(1_000),
+    metrics: z.array(z.string().trim().min(1).max(128)).min(1).max(50),
+    order_by: z
+      .object({ direction: z.enum(["asc", "desc"]), field: z.string().trim().min(1).max(128) })
+      .strict()
+      .optional(),
+    time_range: z
+      .object({ end: utcTimestampSchema, start: utcTimestampSchema })
+      .strict()
+      .refine((value) => Date.parse(value.start) < Date.parse(value.end), {
+        message: "time_range.start must be before time_range.end.",
+        path: ["end"],
+      }),
+  })
+  .strict()
+  .superRefine((query, context) => {
+    if (
+      query.classifier_dimensions &&
+      query.classifier_filters &&
+      query.classifier_dimensions.classifier_id !== query.classifier_filters.classifier_id
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "classifier_dimensions and classifier_filters must use the same classifier_id.",
+        path: ["classifier_filters", "classifier_id"],
+      });
+    }
+  });
+
+const paginationLinksSchema = z
+  .object({
+    next: z.string().nullable().optional(),
+    prev: z.string().nullable().optional(),
+    previous: z.string().nullable().optional(),
   })
   .passthrough();
 
 const modelsResponseSchema = z
   .object({
     data: z.array(openRouterModelSchema),
+    links: paginationLinksSchema,
+    total_count: z.number().int().nonnegative(),
+  })
+  .passthrough();
+
+const modelResponseSchema = z.object({ data: openRouterModelSchema }).passthrough();
+const endpointsResponseSchema = z.object({ data: openRouterModelEndpointsSchema }).passthrough();
+const generationResponseSchema = z.object({ data: openRouterGenerationSchema }).passthrough();
+const providersResponseSchema = z.object({ data: z.array(openRouterProviderSchema) }).passthrough();
+const creditsResponseSchema = z.object({ data: openRouterCreditsSchema }).passthrough();
+const activityResponseSchema = z.object({ data: z.array(openRouterActivityItemSchema) }).passthrough();
+const modelRankingsResponseSchema = z
+  .object({
+    data: z.array(openRouterModelRankingItemSchema),
+    meta: openRouterRankingsMetaSchema,
+  })
+  .passthrough();
+const appRankingsResponseSchema = z
+  .object({
+    data: z.array(openRouterAppRankingItemSchema),
+    meta: openRouterRankingsMetaSchema,
+  })
+  .passthrough();
+const analyticsMetaResponseSchema = z.object({ data: openRouterAnalyticsMetaSchema }).passthrough();
+const analyticsQueryResponseSchema = z
+  .object({
+    data: z.object({
+      cachedAt: z.number().nonnegative().optional(),
+      data: z.array(openRouterAnalyticsRowSchema),
+      metadata: openRouterAnalyticsQueryMetadataSchema,
+      warnings: z.array(z.string()).optional(),
+    }),
   })
   .passthrough();
 
@@ -74,33 +418,189 @@ const chatCompletionResponseSchema = z
           .passthrough(),
       )
       .min(1),
+    id: z.string(),
+    model: z.string().optional(),
     usage: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();
 
+export type OpenRouterPricing = z.infer<typeof openRouterPricingSchema>;
 export type OpenRouterModel = z.infer<typeof openRouterModelSchema>;
+export type OpenRouterEndpoint = z.infer<typeof openRouterEndpointSchema>;
+export type OpenRouterModelEndpoints = z.infer<typeof openRouterModelEndpointsSchema>;
+export type OpenRouterGeneration = z.infer<typeof openRouterGenerationSchema>;
+export type OpenRouterProvider = z.infer<typeof openRouterProviderSchema>;
+export type OpenRouterCredits = z.infer<typeof openRouterCreditsSchema>;
+export type OpenRouterActivityItem = z.infer<typeof openRouterActivityItemSchema>;
+export type OpenRouterRankingsMeta = z.infer<typeof openRouterRankingsMetaSchema>;
+export type OpenRouterModelRankingItem = z.infer<typeof openRouterModelRankingItemSchema>;
+export type OpenRouterAppRankingItem = z.infer<typeof openRouterAppRankingItemSchema>;
+export type OpenRouterAnalyticsMeta = z.infer<typeof openRouterAnalyticsMetaSchema>;
+export type OpenRouterAnalyticsQuery = z.infer<typeof openRouterAnalyticsQuerySchema>;
+export type OpenRouterAnalyticsQueryResult = z.infer<typeof openRouterAnalyticsQueryResultSchema>;
+
+export const MODEL_CATEGORIES = [
+  "programming",
+  "roleplay",
+  "marketing",
+  "marketing/seo",
+  "technology",
+  "science",
+  "translation",
+  "legal",
+  "finance",
+  "health",
+  "trivia",
+  "academia",
+] as const;
+
+export const MODEL_SORTS = [
+  "most-popular",
+  "newest",
+  "top-weekly",
+  "pricing-low-to-high",
+  "pricing-high-to-low",
+  "context-high-to-low",
+  "throughput-high-to-low",
+  "latency-low-to-high",
+  "intelligence-high-to-low",
+  "coding-high-to-low",
+  "agentic-high-to-low",
+  "design-arena-elo-high-to-low",
+] as const;
+
+export const INPUT_MODALITIES = ["text", "image", "audio", "file"] as const;
+export const OUTPUT_MODALITIES = [
+  "text",
+  "image",
+  "embeddings",
+  "audio",
+  "video",
+  "rerank",
+  "speech",
+  "transcription",
+] as const;
+
+export const APP_RANKING_CATEGORIES = ["coding", "creative", "productivity", "entertainment"] as const;
+export const APP_RANKING_SUBCATEGORIES = [
+  "cli-agent",
+  "ide-extension",
+  "cloud-agent",
+  "programming-app",
+  "native-app-builder",
+  "creative-writing",
+  "video-gen",
+  "image-gen",
+  "audio-gen",
+  "roleplay",
+  "game",
+  "writing-assistant",
+  "general-chat",
+  "personal-agent",
+  "legal",
+] as const;
 
 export interface ListModelsOptions {
+  architecture?: string;
+  category?: (typeof MODEL_CATEGORIES)[number];
+  distillable?: boolean;
+  inputModalities?: Array<(typeof INPUT_MODALITIES)[number]>;
+  limit?: number;
+  maxAgenticIndex?: number;
+  maxAgeDays?: number;
+  maxCodingIndex?: number;
+  maxIntelligenceIndex?: number;
+  maxOutputPrice?: number;
+  maxPromptPrice?: number;
+  maxToolSuccessRate?: number;
+  minAgenticIndex?: number;
+  minAgeDays?: number;
+  minCodingIndex?: number;
+  minContextLength?: number;
+  minIntelligenceIndex?: number;
+  minOutputPrice?: number;
+  minPromptPrice?: number;
+  minToolSuccessRate?: number;
+  modelAuthors?: string[];
+  offset?: number;
+  outputModalities?: Array<(typeof OUTPUT_MODALITIES)[number]> | "all";
+  providers?: string[];
   q?: string;
+  region?: "eu" | "us";
+  sort?: (typeof MODEL_SORTS)[number];
+  supportedParameters?: string[];
+  zdr?: boolean;
+}
+
+export interface ListModelsResult {
+  links: {
+    next?: string | null;
+    previous?: string | null;
+  };
+  models: OpenRouterModel[];
+  totalCount: number;
 }
 
 export interface ChatCompletionRequest {
-  model: string;
-  message: string;
   maxCompletionTokens: number;
-  temperature: number;
+  message: string;
+  model: string;
   systemPrompt?: string;
+  temperature: number;
 }
 
 export interface ChatCompletionResult {
   content: unknown;
+  generationId: string;
+  resolvedModel?: string;
   usage?: Record<string, unknown>;
 }
 
+export interface ActivityOptions {
+  apiKeyHash?: string;
+  date?: string;
+  groupBy?: "workspace";
+  userId?: string;
+  workspaceId?: string;
+}
+
+export interface ModelRankingsOptions {
+  contextBucket?: "1K" | "10K" | "100K" | "1M" | "10M";
+  endDate?: string;
+  modality?: "text" | "image" | "image_output" | "audio" | "tool_calling";
+  period?: "day" | "week" | "month";
+  startDate?: string;
+}
+
+export interface AppRankingsOptions {
+  category?: (typeof APP_RANKING_CATEGORIES)[number];
+  endDate?: string;
+  limit?: number;
+  offset?: number;
+  sort?: "popular" | "trending";
+  startDate?: string;
+  subcategory?: (typeof APP_RANKING_SUBCATEGORIES)[number];
+}
+
+export interface RankingsResult<T> {
+  data: T[];
+  meta: OpenRouterRankingsMeta;
+}
+
 export interface OpenRouterApi {
-  listModels(options: ListModelsOptions, signal?: AbortSignal): Promise<OpenRouterModel[]>;
-  getCurrentKey(signal?: AbortSignal): Promise<Record<string, unknown>>;
   createChatCompletion(request: ChatCompletionRequest, signal?: AbortSignal): Promise<ChatCompletionResult>;
+  getAnalyticsMeta(signal?: AbortSignal): Promise<OpenRouterAnalyticsMeta>;
+  getActivity(options?: ActivityOptions, signal?: AbortSignal): Promise<OpenRouterActivityItem[]>;
+  getAppRankings(options?: AppRankingsOptions, signal?: AbortSignal): Promise<RankingsResult<OpenRouterAppRankingItem>>;
+  getCredits(signal?: AbortSignal): Promise<OpenRouterCredits>;
+  getCurrentKey(signal?: AbortSignal): Promise<Record<string, unknown>>;
+  getGeneration(generationId: string, signal?: AbortSignal): Promise<OpenRouterGeneration>;
+  getModelRankings(options?: ModelRankingsOptions, signal?: AbortSignal): Promise<RankingsResult<OpenRouterModelRankingItem>>;
+  getModel(modelId: string, signal?: AbortSignal): Promise<OpenRouterModel>;
+  getModelEndpoints(modelId: string, signal?: AbortSignal): Promise<OpenRouterModelEndpoints>;
+  listModels(options?: ListModelsOptions, signal?: AbortSignal): Promise<ListModelsResult>;
+  listProviders(signal?: AbortSignal): Promise<OpenRouterProvider[]>;
+  queryAnalytics(request: OpenRouterAnalyticsQuery, signal?: AbortSignal): Promise<OpenRouterAnalyticsQueryResult>;
 }
 
 export interface OpenRouterClientOptions {
@@ -108,9 +608,12 @@ export interface OpenRouterClientOptions {
   appName?: string;
   baseUrl?: string;
   fetch?: typeof globalThis.fetch;
+  managementApiKey?: string;
   siteUrl?: string;
   timeoutMs?: number;
 }
+
+type AuthenticationMode = "none" | "api" | "management";
 
 export class OpenRouterHttpError extends Error {
   readonly status: number;
@@ -127,6 +630,7 @@ export class OpenRouterClient implements OpenRouterApi {
   private readonly appName?: string;
   private readonly baseUrl: URL;
   private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly managementApiKey?: string;
   private readonly siteUrl?: string;
   private readonly timeoutMs: number;
 
@@ -135,6 +639,7 @@ export class OpenRouterClient implements OpenRouterApi {
     this.appName = cleanOptional(options.appName) ?? "OpenRouter MCP Server";
     this.baseUrl = normalizeBaseUrl(options.baseUrl ?? "https://openrouter.ai/api/v1");
     this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.managementApiKey = cleanOptional(options.managementApiKey) ?? this.apiKey;
     this.siteUrl = cleanOptional(options.siteUrl);
     this.timeoutMs = options.timeoutMs ?? 60_000;
 
@@ -148,30 +653,174 @@ export class OpenRouterClient implements OpenRouterApi {
       apiKey: environment.OPENROUTER_API_KEY,
       appName: environment.OPENROUTER_APP_NAME,
       baseUrl: environment.OPENROUTER_BASE_URL,
+      managementApiKey: environment.OPENROUTER_MANAGEMENT_KEY,
       siteUrl: environment.OPENROUTER_SITE_URL,
       timeoutMs: parseTimeout(environment.OPENROUTER_TIMEOUT_MS),
     });
   }
 
-  async listModels(options: ListModelsOptions = {}, signal?: AbortSignal): Promise<OpenRouterModel[]> {
+  async listModels(options: ListModelsOptions = {}, signal?: AbortSignal): Promise<ListModelsResult> {
     const url = new URL("models", this.baseUrl);
-    const query = cleanOptional(options.q);
-    if (query) {
-      url.searchParams.set("q", query);
-    }
+    setQuery(url, "offset", options.offset ?? 0);
+    setQuery(url, "limit", options.limit ?? 25);
+    setQuery(url, "q", cleanOptional(options.q));
+    setQuery(url, "category", options.category);
+    setQuery(url, "supported_parameters", joinQuery(options.supportedParameters));
+    setQuery(
+      url,
+      "output_modalities",
+      options.outputModalities === "all" ? "all" : joinQuery(options.outputModalities),
+    );
+    setQuery(url, "sort", options.sort);
+    setQuery(url, "input_modalities", joinQuery(options.inputModalities));
+    setQuery(url, "context", options.minContextLength);
+    setQuery(url, "min_price", options.minPromptPrice);
+    setQuery(url, "max_price", options.maxPromptPrice);
+    setQuery(url, "arch", cleanOptional(options.architecture));
+    setQuery(url, "model_authors", joinQuery(options.modelAuthors));
+    setQuery(url, "providers", joinQuery(options.providers));
+    setQuery(url, "distillable", options.distillable);
+    setQuery(url, "zdr", options.zdr);
+    setQuery(url, "region", options.region);
+    setQuery(url, "min_output_price", options.minOutputPrice);
+    setQuery(url, "max_output_price", options.maxOutputPrice);
+    setQuery(url, "min_age_days", options.minAgeDays);
+    setQuery(url, "max_age_days", options.maxAgeDays);
+    setQuery(url, "min_intelligence_index", options.minIntelligenceIndex);
+    setQuery(url, "max_intelligence_index", options.maxIntelligenceIndex);
+    setQuery(url, "min_coding_index", options.minCodingIndex);
+    setQuery(url, "max_coding_index", options.maxCodingIndex);
+    setQuery(url, "min_agentic_index", options.minAgenticIndex);
+    setQuery(url, "max_agentic_index", options.maxAgenticIndex);
+    setQuery(url, "min_tool_success_rate", options.minToolSuccessRate);
+    setQuery(url, "max_tool_success_rate", options.maxToolSuccessRate);
 
-    const payload = await this.request(url, { method: "GET" }, signal, false);
-    return modelsResponseSchema.parse(payload).data;
+    const payload = await this.request(url, { method: "GET" }, signal, "none");
+    const response = modelsResponseSchema.parse(payload);
+    return {
+      models: response.data,
+      totalCount: response.total_count,
+      links: {
+        next: response.links.next,
+        previous: response.links.previous ?? response.links.prev,
+      },
+    };
+  }
+
+  async getModel(modelId: string, signal?: AbortSignal): Promise<OpenRouterModel> {
+    const [author, slug] = parseModelId(modelId);
+    const url = new URL("model/" + encodeURIComponent(author) + "/" + encodeURIComponent(slug), this.baseUrl);
+    const payload = await this.request(url, { method: "GET" }, signal, "none");
+    return modelResponseSchema.parse(payload).data;
+  }
+
+  async getModelEndpoints(modelId: string, signal?: AbortSignal): Promise<OpenRouterModelEndpoints> {
+    const [author, slug] = parseModelId(modelId);
+    const url = new URL(
+      "models/" + encodeURIComponent(author) + "/" + encodeURIComponent(slug) + "/endpoints",
+      this.baseUrl,
+    );
+    const payload = await this.request(url, { method: "GET" }, signal, "none");
+    return endpointsResponseSchema.parse(payload).data;
+  }
+
+  async listProviders(signal?: AbortSignal): Promise<OpenRouterProvider[]> {
+    const payload = await this.request(new URL("providers", this.baseUrl), { method: "GET" }, signal, "none");
+    return providersResponseSchema.parse(payload).data;
+  }
+
+  async getCredits(signal?: AbortSignal): Promise<OpenRouterCredits> {
+    const payload = await this.request(new URL("credits", this.baseUrl), { method: "GET" }, signal, "management");
+    return creditsResponseSchema.parse(payload).data;
+  }
+
+  async getActivity(
+    options: ActivityOptions = {},
+    signal?: AbortSignal,
+  ): Promise<OpenRouterActivityItem[]> {
+    const url = new URL("activity", this.baseUrl);
+    setQuery(url, "api_key_hash", cleanOptional(options.apiKeyHash));
+    setQuery(url, "date", cleanOptional(options.date));
+    setQuery(url, "group_by", options.groupBy);
+    setQuery(url, "user_id", cleanOptional(options.userId));
+    setQuery(url, "workspace_id", cleanOptional(options.workspaceId));
+    const payload = await this.request(url, { method: "GET" }, signal, "management");
+    return activityResponseSchema.parse(payload).data;
+  }
+
+  async getAnalyticsMeta(signal?: AbortSignal): Promise<OpenRouterAnalyticsMeta> {
+    const payload = await this.request(
+      new URL("analytics/meta", this.baseUrl),
+      { method: "GET" },
+      signal,
+      "management",
+    );
+    return analyticsMetaResponseSchema.parse(payload).data;
+  }
+
+  async queryAnalytics(
+    request: OpenRouterAnalyticsQuery,
+    signal?: AbortSignal,
+  ): Promise<OpenRouterAnalyticsQueryResult> {
+    const validated = openRouterAnalyticsQuerySchema.parse(request);
+    const payload = await this.request(
+      new URL("analytics/query", this.baseUrl),
+      { method: "POST", body: JSON.stringify(validated) },
+      signal,
+      "management",
+    );
+    const response = analyticsQueryResponseSchema.parse(payload).data;
+    return openRouterAnalyticsQueryResultSchema.parse({
+      cached_at: response.cachedAt,
+      metadata: response.metadata,
+      rows: response.data,
+      warnings: response.warnings,
+    });
+  }
+
+  async getModelRankings(
+    options: ModelRankingsOptions = {},
+    signal?: AbortSignal,
+  ): Promise<RankingsResult<OpenRouterModelRankingItem>> {
+    const url = new URL("datasets/rankings-daily", this.baseUrl);
+    setQuery(url, "context_bucket", options.contextBucket);
+    setQuery(url, "end_date", cleanOptional(options.endDate));
+    setQuery(url, "modality", options.modality);
+    setQuery(url, "period", options.period);
+    setQuery(url, "start_date", cleanOptional(options.startDate));
+    const payload = await this.request(url, { method: "GET" }, signal, "api");
+    return modelRankingsResponseSchema.parse(payload);
+  }
+
+  async getAppRankings(
+    options: AppRankingsOptions = {},
+    signal?: AbortSignal,
+  ): Promise<RankingsResult<OpenRouterAppRankingItem>> {
+    const url = new URL("datasets/app-rankings", this.baseUrl);
+    setQuery(url, "category", options.category);
+    setQuery(url, "end_date", cleanOptional(options.endDate));
+    setQuery(url, "limit", options.limit);
+    setQuery(url, "offset", options.offset);
+    setQuery(url, "sort", options.sort);
+    setQuery(url, "start_date", cleanOptional(options.startDate));
+    setQuery(url, "subcategory", options.subcategory);
+    const payload = await this.request(url, { method: "GET" }, signal, "api");
+    return appRankingsResponseSchema.parse(payload);
+  }
+
+  async getGeneration(generationId: string, signal?: AbortSignal): Promise<OpenRouterGeneration> {
+    const url = new URL("generation", this.baseUrl);
+    url.searchParams.set("id", generationId);
+    const payload = await this.request(url, { method: "GET" }, signal, "api");
+    return generationResponseSchema.parse(payload).data;
   }
 
   async getCurrentKey(signal?: AbortSignal): Promise<Record<string, unknown>> {
-    this.assertApiKey();
-    const payload = await this.request(new URL("key", this.baseUrl), { method: "GET" }, signal, true);
+    const payload = await this.request(new URL("key", this.baseUrl), { method: "GET" }, signal, "api");
     return keyResponseSchema.parse(payload).data;
   }
 
   async createChatCompletion(request: ChatCompletionRequest, signal?: AbortSignal): Promise<ChatCompletionResult> {
-    this.assertApiKey();
     const messages: Array<{ role: "system" | "user"; content: string }> = [];
     if (request.systemPrompt) {
       messages.push({ role: "system", content: request.systemPrompt });
@@ -190,7 +839,7 @@ export class OpenRouterClient implements OpenRouterApi {
         }),
       },
       signal,
-      true,
+      "api",
     );
     const completion = chatCompletionResponseSchema.parse(payload);
     const firstChoice = completion.choices[0];
@@ -200,25 +849,19 @@ export class OpenRouterClient implements OpenRouterApi {
 
     return {
       content: firstChoice.message.content,
+      generationId: completion.id,
+      resolvedModel: completion.model,
       usage: completion.usage,
     };
-  }
-
-  private assertApiKey(): void {
-    if (!this.apiKey) {
-      throw new Error("OPENROUTER_API_KEY is required for this operation.");
-    }
   }
 
   private async request(
     url: URL,
     init: RequestInit,
     upstreamSignal: AbortSignal | undefined,
-    requiresApiKey: boolean,
+    authentication: AuthenticationMode,
   ): Promise<unknown> {
-    if (requiresApiKey) {
-      this.assertApiKey();
-    }
+    const credential = this.credentialFor(authentication);
 
     const controller = new AbortController();
     let timedOut = false;
@@ -239,8 +882,8 @@ export class OpenRouterClient implements OpenRouterApi {
     if (init.body !== undefined) {
       headers.set("Content-Type", "application/json");
     }
-    if (this.apiKey) {
-      headers.set("Authorization", "Bearer " + this.apiKey);
+    if (credential) {
+      headers.set("Authorization", "Bearer " + credential);
     }
     if (this.siteUrl) {
       headers.set("HTTP-Referer", this.siteUrl);
@@ -281,6 +924,45 @@ export class OpenRouterClient implements OpenRouterApi {
       upstreamSignal?.removeEventListener("abort", cancel);
     }
   }
+
+  private credentialFor(authentication: AuthenticationMode): string | undefined {
+    if (authentication === "none") {
+      return undefined;
+    }
+    if (authentication === "api") {
+      if (!this.apiKey) {
+        throw new Error("OPENROUTER_API_KEY is required for this operation.");
+      }
+      return this.apiKey;
+    }
+    if (!this.managementApiKey) {
+      throw new Error(
+        "OPENROUTER_MANAGEMENT_KEY is required for this operation (OPENROUTER_API_KEY is accepted when it is a management key).",
+      );
+    }
+    return this.managementApiKey;
+  }
+}
+
+function setQuery(url: URL, name: string, value: string | number | boolean | undefined): void {
+  if (value !== undefined) {
+    url.searchParams.set(name, String(value));
+  }
+}
+
+function joinQuery(values: readonly string[] | undefined): string | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+  return values.join(",");
+}
+
+function parseModelId(modelId: string): [author: string, slug: string] {
+  const separator = modelId.indexOf("/");
+  if (separator <= 0 || separator === modelId.length - 1 || modelId.indexOf("/", separator + 1) !== -1) {
+    throw new Error("OpenRouter model ID must use the author/slug format.");
+  }
+  return [modelId.slice(0, separator), modelId.slice(separator + 1)];
 }
 
 function cleanOptional(value: string | undefined): string | undefined {
@@ -291,10 +973,17 @@ function cleanOptional(value: string | undefined): string | undefined {
 function normalizeBaseUrl(value: string): URL {
   const normalized = value.endsWith("/") ? value : value + "/";
   const url = new URL(normalized);
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new Error("OPENROUTER_BASE_URL must use http or https.");
+  if (url.username || url.password) {
+    throw new Error("OPENROUTER_BASE_URL must not contain credentials.");
+  }
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopbackHost(url.hostname))) {
+    throw new Error("OPENROUTER_BASE_URL must use HTTPS; HTTP is allowed only for loopback development.");
   }
   return url;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
 }
 
 function parseTimeout(value: string | undefined): number | undefined {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,0 +1,562 @@
+import type {
+  AppRankingsOptions,
+  ListModelsOptions,
+  OpenRouterActivityItem,
+  OpenRouterApi,
+  OpenRouterAppRankingItem,
+  OpenRouterAnalyticsMeta,
+  OpenRouterAnalyticsQuery,
+  OpenRouterAnalyticsQueryResult,
+  OpenRouterCredits,
+  OpenRouterEndpoint,
+  OpenRouterGeneration,
+  OpenRouterModel,
+  OpenRouterPricing,
+  OpenRouterProvider,
+  OpenRouterRankingsMeta,
+} from "./openrouter.js";
+
+const COMPARE_CONCURRENCY = 3;
+
+export interface ListModelsInput {
+  architecture?: string;
+  category?: ListModelsOptions["category"];
+  distillable?: boolean;
+  input_modalities?: ListModelsOptions["inputModalities"];
+  limit: number;
+  max_agentic_index?: number;
+  max_age_days?: number;
+  max_coding_index?: number;
+  max_intelligence_index?: number;
+  max_output_price?: number;
+  max_prompt_price?: number;
+  max_tool_success_rate?: number;
+  min_agentic_index?: number;
+  min_age_days?: number;
+  min_coding_index?: number;
+  min_context_length?: number;
+  min_intelligence_index?: number;
+  min_output_price?: number;
+  min_prompt_price?: number;
+  min_tool_success_rate?: number;
+  model_authors?: string[];
+  offset: number;
+  output_modalities?: ListModelsOptions["outputModalities"];
+  providers?: string[];
+  q?: string;
+  region?: ListModelsOptions["region"];
+  sort?: ListModelsOptions["sort"];
+  supported_parameters?: string[];
+  zdr?: true;
+}
+
+export interface ModelSummary {
+  agentic_index?: number | null;
+  canonical_slug?: string;
+  coding_index?: number | null;
+  context_length?: number;
+  created?: number;
+  id: string;
+  input_modalities?: string[];
+  intelligence_index?: number | null;
+  max_completion_tokens?: number | null;
+  name?: string;
+  output_modalities?: string[];
+  pricing?: OpenRouterPricing;
+}
+
+export interface ListModelsOutput {
+  has_more: boolean;
+  models: ModelSummary[];
+  next_offset: number | null;
+  offset: number;
+  returned: number;
+  total_count: number;
+}
+
+export interface ListModelEndpointsInput {
+  limit: number;
+  model: string;
+  offset: number;
+  provider?: string;
+}
+
+export interface ListModelEndpointsOutput {
+  endpoints: OpenRouterEndpoint[];
+  has_more: boolean;
+  model: { id: string; name?: string };
+  next_offset: number | null;
+  offset: number;
+  returned: number;
+  total_count: number;
+}
+
+export interface ChatInput {
+  max_completion_tokens: number;
+  message: string;
+  model: string;
+  system_prompt?: string;
+  temperature: number;
+}
+
+export interface ChatOutput {
+  generation_id: string;
+  requested_model: string;
+  resolved_model: string | null;
+  response: string;
+  usage: Record<string, unknown> | null;
+}
+
+export interface CompareInput {
+  max_completion_tokens: number;
+  message: string;
+  models: string[];
+}
+
+export interface ComparisonResult {
+  error?: string;
+  generation_id?: string;
+  requested_model: string;
+  resolved_model?: string | null;
+  response?: string;
+  success: boolean;
+  usage?: Record<string, unknown> | null;
+}
+
+export interface CompareOutput {
+  results: ComparisonResult[];
+}
+
+export interface ListProvidersInput {
+  datacenter?: string;
+  headquarters?: string;
+  limit: number;
+  offset: number;
+  q?: string;
+}
+
+export interface ListProvidersOutput {
+  has_more: boolean;
+  next_offset: number | null;
+  offset: number;
+  providers: OpenRouterProvider[];
+  returned: number;
+  total_count: number;
+}
+
+export interface CreditsOutput extends OpenRouterCredits {
+  remaining_credits: number;
+}
+
+export interface ListActivityInput {
+  api_key_hash?: string;
+  date?: string;
+  group_by?: "workspace";
+  limit: number;
+  offset: number;
+  user_id?: string;
+  workspace_id?: string;
+}
+
+export interface ListActivityOutput {
+  activity: OpenRouterActivityItem[];
+  date: string;
+  has_more: boolean;
+  next_offset: number | null;
+  offset: number;
+  returned: number;
+  total_count: number;
+}
+
+export type AnalyticsQueryInput = OpenRouterAnalyticsQuery;
+export type AnalyticsQueryOutput = OpenRouterAnalyticsQueryResult;
+
+export interface ListModelRankingsInput {
+  context_bucket?: "1K" | "10K" | "100K" | "1M" | "10M";
+  date?: string;
+  include_other: boolean;
+  limit: number;
+  modality?: "text" | "image" | "image_output" | "audio" | "tool_calling";
+}
+
+export interface RankedModel {
+  date: string;
+  model_permaslug: string;
+  rank: number;
+  total_tokens: string;
+}
+
+export interface ListModelRankingsOutput {
+  attribution: string;
+  date: string;
+  rankings: RankedModel[];
+  returned: number;
+  meta: OpenRouterRankingsMeta;
+}
+
+export interface ListAppRankingsInput {
+  category?: AppRankingsOptions["category"];
+  end_date?: string;
+  limit: number;
+  offset: number;
+  sort: "popular" | "trending";
+  start_date?: string;
+  subcategory?: AppRankingsOptions["subcategory"];
+}
+
+export interface ListAppRankingsOutput {
+  apps: OpenRouterAppRankingItem[];
+  attribution: string;
+  has_more: boolean;
+  meta: OpenRouterRankingsMeta;
+  next_offset: number | null;
+  offset: number;
+  returned: number;
+}
+
+export async function listModels(
+  api: OpenRouterApi,
+  input: ListModelsInput,
+  signal?: AbortSignal,
+): Promise<ListModelsOutput> {
+  const options: ListModelsOptions = {
+    architecture: input.architecture,
+    category: input.category,
+    distillable: input.distillable,
+    inputModalities: input.input_modalities,
+    limit: input.limit,
+    maxAgenticIndex: input.max_agentic_index,
+    maxAgeDays: input.max_age_days,
+    maxCodingIndex: input.max_coding_index,
+    maxIntelligenceIndex: input.max_intelligence_index,
+    maxOutputPrice: input.max_output_price,
+    maxPromptPrice: input.max_prompt_price,
+    maxToolSuccessRate: input.max_tool_success_rate,
+    minAgenticIndex: input.min_agentic_index,
+    minAgeDays: input.min_age_days,
+    minCodingIndex: input.min_coding_index,
+    minContextLength: input.min_context_length,
+    minIntelligenceIndex: input.min_intelligence_index,
+    minOutputPrice: input.min_output_price,
+    minPromptPrice: input.min_prompt_price,
+    minToolSuccessRate: input.min_tool_success_rate,
+    modelAuthors: input.model_authors,
+    offset: input.offset,
+    outputModalities: input.output_modalities,
+    providers: input.providers,
+    q: input.q,
+    region: input.region,
+    sort: input.sort,
+    supportedParameters: input.supported_parameters,
+    zdr: input.zdr,
+  };
+  const page = await api.listModels(options, signal);
+  const models = page.models.map(summarizeModel);
+  const hasMore = models.length > 0 && input.offset + models.length < page.totalCount;
+  return {
+    has_more: hasMore,
+    models,
+    next_offset: hasMore ? input.offset + models.length : null,
+    offset: input.offset,
+    returned: models.length,
+    total_count: page.totalCount,
+  };
+}
+
+export async function getModel(
+  api: OpenRouterApi,
+  model: string,
+  signal?: AbortSignal,
+): Promise<{ model: OpenRouterModel }> {
+  return { model: await api.getModel(model, signal) };
+}
+
+export async function listModelEndpoints(
+  api: OpenRouterApi,
+  input: ListModelEndpointsInput,
+  signal?: AbortSignal,
+): Promise<ListModelEndpointsOutput> {
+  const result = await api.getModelEndpoints(input.model, signal);
+  const query = input.provider?.toLowerCase();
+  const filtered = query
+    ? result.endpoints.filter((endpoint) =>
+        [endpoint.provider_name, endpoint.tag, endpoint.name].some((value) => value?.toLowerCase().includes(query)),
+      )
+    : result.endpoints;
+  const endpoints = filtered.slice(input.offset, input.offset + input.limit);
+  const hasMore = endpoints.length > 0 && input.offset + endpoints.length < filtered.length;
+  return {
+    endpoints,
+    has_more: hasMore,
+    model: { id: result.id, name: result.name },
+    next_offset: hasMore ? input.offset + endpoints.length : null,
+    offset: input.offset,
+    returned: endpoints.length,
+    total_count: filtered.length,
+  };
+}
+
+export async function chatWithModel(
+  api: OpenRouterApi,
+  input: ChatInput,
+  signal?: AbortSignal,
+): Promise<ChatOutput> {
+  const result = await api.createChatCompletion(
+    {
+      model: input.model,
+      message: input.message,
+      maxCompletionTokens: input.max_completion_tokens,
+      temperature: input.temperature,
+      systemPrompt: input.system_prompt,
+    },
+    signal,
+  );
+  return {
+    generation_id: result.generationId,
+    requested_model: input.model,
+    resolved_model: result.resolvedModel ?? null,
+    response: normalizeContent(result.content),
+    usage: result.usage ?? null,
+  };
+}
+
+export async function compareModels(
+  api: OpenRouterApi,
+  input: CompareInput,
+  signal?: AbortSignal,
+): Promise<CompareOutput> {
+  const results = await mapWithConcurrency(input.models, COMPARE_CONCURRENCY, async (model) => {
+    try {
+      const result = await api.createChatCompletion(
+        {
+          model,
+          message: input.message,
+          maxCompletionTokens: input.max_completion_tokens,
+          temperature: 0.7,
+        },
+        signal,
+      );
+      return {
+        generation_id: result.generationId,
+        requested_model: model,
+        resolved_model: result.resolvedModel ?? null,
+        success: true,
+        response: normalizeContent(result.content),
+        usage: result.usage ?? null,
+      };
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      return {
+        requested_model: model,
+        success: false,
+        error: toErrorMessage(error),
+      };
+    }
+  });
+  return { results };
+}
+
+export async function getGeneration(
+  api: OpenRouterApi,
+  generationId: string,
+  signal?: AbortSignal,
+): Promise<{ generation: OpenRouterGeneration }> {
+  return { generation: await api.getGeneration(generationId, signal) };
+}
+
+export async function listProviders(
+  api: OpenRouterApi,
+  input: ListProvidersInput,
+  signal?: AbortSignal,
+): Promise<ListProvidersOutput> {
+  const providers = await api.listProviders(signal);
+  const query = input.q?.toLowerCase();
+  const datacenter = input.datacenter?.toUpperCase();
+  const headquarters = input.headquarters?.toUpperCase();
+  const filtered = providers.filter((provider) => {
+    if (query && !provider.name.toLowerCase().includes(query) && !provider.slug.toLowerCase().includes(query)) {
+      return false;
+    }
+    if (datacenter && !provider.datacenters?.includes(datacenter)) {
+      return false;
+    }
+    return !headquarters || provider.headquarters === headquarters;
+  });
+  const page = filtered.slice(input.offset, input.offset + input.limit);
+  const hasMore = page.length > 0 && input.offset + page.length < filtered.length;
+  return {
+    has_more: hasMore,
+    next_offset: hasMore ? input.offset + page.length : null,
+    offset: input.offset,
+    providers: page,
+    returned: page.length,
+    total_count: filtered.length,
+  };
+}
+
+export async function getCredits(api: OpenRouterApi, signal?: AbortSignal): Promise<CreditsOutput> {
+  const credits = await api.getCredits(signal);
+  return {
+    ...credits,
+    remaining_credits: Math.max(0, credits.total_credits - credits.total_usage),
+  };
+}
+
+export async function listActivity(
+  api: OpenRouterApi,
+  input: ListActivityInput,
+  signal?: AbortSignal,
+): Promise<ListActivityOutput> {
+  const date = input.date ?? mostRecentCompletedUtcDate();
+  const activity = await api.getActivity(
+    {
+      apiKeyHash: input.api_key_hash,
+      date,
+      groupBy: input.group_by,
+      userId: input.user_id,
+      workspaceId: input.workspace_id,
+    },
+    signal,
+  );
+  const page = activity.slice(input.offset, input.offset + input.limit);
+  const hasMore = page.length > 0 && input.offset + page.length < activity.length;
+  return {
+    activity: page,
+    date,
+    has_more: hasMore,
+    next_offset: hasMore ? input.offset + page.length : null,
+    offset: input.offset,
+    returned: page.length,
+    total_count: activity.length,
+  };
+}
+
+export async function getAnalyticsSchema(
+  api: OpenRouterApi,
+  signal?: AbortSignal,
+): Promise<{ schema: OpenRouterAnalyticsMeta }> {
+  return { schema: await api.getAnalyticsMeta(signal) };
+}
+
+export async function queryAnalytics(
+  api: OpenRouterApi,
+  input: AnalyticsQueryInput,
+  signal?: AbortSignal,
+): Promise<AnalyticsQueryOutput> {
+  return api.queryAnalytics(input, signal);
+}
+
+export async function listModelRankings(
+  api: OpenRouterApi,
+  input: ListModelRankingsInput,
+  signal?: AbortSignal,
+): Promise<ListModelRankingsOutput> {
+  const date = input.date ?? mostRecentCompletedUtcDate();
+  const result = await api.getModelRankings(
+    {
+      contextBucket: input.context_bucket,
+      endDate: date,
+      modality: input.modality,
+      period: "day",
+      startDate: date,
+    },
+    signal,
+  );
+  const rankings = result.data
+    .filter((item) => input.include_other || item.model_permaslug !== "other")
+    .slice(0, input.limit)
+    .map((item, index) => ({ ...item, rank: index + 1 }));
+  return {
+    attribution: "Source: OpenRouter (openrouter.ai/rankings), as of " + result.meta.as_of + ".",
+    date,
+    rankings,
+    returned: rankings.length,
+    meta: result.meta,
+  };
+}
+
+export async function listAppRankings(
+  api: OpenRouterApi,
+  input: ListAppRankingsInput,
+  signal?: AbortSignal,
+): Promise<ListAppRankingsOutput> {
+  const result = await api.getAppRankings(
+    {
+      category: input.category,
+      endDate: input.end_date,
+      limit: Math.min(100, input.limit + 1),
+      offset: input.offset,
+      sort: input.sort,
+      startDate: input.start_date,
+      subcategory: input.subcategory,
+    },
+    signal,
+  );
+  const apps = result.data.slice(0, input.limit);
+  const hasMore = result.data.length > input.limit;
+  return {
+    apps,
+    attribution: "Source: OpenRouter (openrouter.ai/apps), as of " + result.meta.as_of + ".",
+    has_more: hasMore,
+    meta: result.meta,
+    next_offset: hasMore ? input.offset + apps.length : null,
+    offset: input.offset,
+    returned: apps.length,
+  };
+}
+
+export function mostRecentCompletedUtcDate(now: Date = new Date()): string {
+  const completed = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+  return completed.toISOString().slice(0, 10);
+}
+
+function summarizeModel(model: OpenRouterModel): ModelSummary {
+  return {
+    id: model.id,
+    name: model.name,
+    canonical_slug: model.canonical_slug,
+    created: model.created,
+    context_length: model.context_length,
+    input_modalities: model.architecture?.input_modalities,
+    output_modalities: model.architecture?.output_modalities,
+    pricing: model.pricing,
+    max_completion_tokens: model.top_provider?.max_completion_tokens,
+    intelligence_index: model.benchmarks?.artificial_analysis?.intelligence_index,
+    coding_index: model.benchmarks?.artificial_analysis?.coding_index,
+    agentic_index: model.benchmarks?.artificial_analysis?.agentic_index,
+  };
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  operation: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const item = items[index];
+      if (item !== undefined) {
+        results[index] = await operation(item);
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+function normalizeContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  return JSON.stringify(content) ?? String(content);
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createServer } from "node:http";
+import { pathToFileURL } from "node:url";
 
 import { localhostHostValidation, localhostOriginValidation, toNodeHandler } from "@modelcontextprotocol/node";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
@@ -13,15 +14,18 @@ loadEnvironment({ quiet: true });
 
 type Transport = "http" | "stdio";
 
-async function main(): Promise<void> {
-  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+export async function runServer(
+  argumentsList: string[] = process.argv.slice(2),
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (argumentsList.includes("--help") || argumentsList.includes("-h")) {
     printHelp();
     return;
   }
 
-  const transport = readTransport();
-  const api = OpenRouterClient.fromEnvironment();
-  if (!process.env.OPENROUTER_API_KEY?.trim()) {
+  const transport = readTransport(argumentsList, environment);
+  const api = OpenRouterClient.fromEnvironment(environment);
+  if (!environment.OPENROUTER_API_KEY?.trim()) {
     console.error(
       "OPENROUTER_API_KEY is not set. Model discovery can still work, but chat and key-usage calls will fail.",
     );
@@ -34,7 +38,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const port = readPort();
+  const port = readPort(argumentsList, environment);
   const handler = createOpenRouterMcpHandler(api);
   const nodeHandler = toNodeHandler(handler);
   const validateHost = localhostHostValidation();
@@ -82,16 +86,16 @@ async function main(): Promise<void> {
   );
 }
 
-function readTransport(): Transport {
-  const requested = readOption("--transport") ?? process.env.MCP_TRANSPORT ?? "stdio";
+function readTransport(argumentsList: string[], environment: NodeJS.ProcessEnv): Transport {
+  const requested = readOption(argumentsList, "--transport") ?? environment.MCP_TRANSPORT ?? "stdio";
   if (requested !== "stdio" && requested !== "http") {
     throw new Error("MCP transport must be either stdio or http.");
   }
   return requested;
 }
 
-function readPort(): number {
-  const requested = readOption("--port") ?? process.env.MCP_HTTP_PORT ?? "3000";
+function readPort(argumentsList: string[], environment: NodeJS.ProcessEnv): number {
+  const requested = readOption(argumentsList, "--port") ?? environment.MCP_HTTP_PORT ?? "3000";
   const port = Number(requested);
   if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
     throw new Error("MCP HTTP port must be an integer between 1 and 65535.");
@@ -99,10 +103,10 @@ function readPort(): number {
   return port;
 }
 
-function readOption(name: string): string | undefined {
-  const exactIndex = process.argv.indexOf(name);
+function readOption(argumentsList: string[], name: string): string | undefined {
+  const exactIndex = argumentsList.indexOf(name);
   if (exactIndex >= 0) {
-    const value = process.argv[exactIndex + 1];
+    const value = argumentsList[exactIndex + 1];
     if (!value || value.startsWith("--")) {
       throw new Error(name + " requires a value.");
     }
@@ -110,7 +114,7 @@ function readOption(name: string): string | undefined {
   }
 
   const prefix = name + "=";
-  const inline = process.argv.find((argument) => argument.startsWith(prefix));
+  const inline = argumentsList.find((argument) => argument.startsWith(prefix));
   return inline?.slice(prefix.length);
 }
 
@@ -144,7 +148,10 @@ function printHelp(): void {
   );
 }
 
-void main().catch((error: unknown) => {
-  console.error("OpenRouter MCP server failed:", error);
-  process.exitCode = 1;
-});
+const invokedPath = process.argv[1];
+if (invokedPath && pathToFileURL(invokedPath).href === import.meta.url) {
+  void runServer().catch((error: unknown) => {
+    console.error("OpenRouter MCP server failed:", error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/live-contract.ts
+++ b/tests/live-contract.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { config as loadEnvironment } from "dotenv";
+
+import { createOpenRouterMcpHandler } from "../src/mcp.js";
+import { OpenRouterClient, type OpenRouterApi } from "../src/openrouter.js";
+
+loadEnvironment({ quiet: true });
+
+const publicSession = await connectMcp(new OpenRouterClient());
+const listed = await publicSession.client.listTools();
+assert.equal(listed.ttlMs, 3_600_000);
+assert.equal(listed.cacheScope, "public");
+
+const listResult = await publicSession.client.callTool({
+  name: "list_models",
+  arguments: { limit: 2, offset: 0, sort: "newest" },
+});
+assertToolSuccess(listResult, "list_models");
+const page = listResult.structuredContent as {
+  models: Array<{ id: string }>;
+  total_count: number;
+};
+assert.equal(page.models.length, 2);
+assert.ok(page.total_count >= page.models.length);
+
+const first = page.models[0];
+assert.ok(first);
+const modelResult = await publicSession.client.callTool({
+  name: "get_model",
+  arguments: { model: first.id },
+});
+assertToolSuccess(modelResult, "get_model");
+const model = modelResult.structuredContent as { model: { id: string } };
+assert.equal(model.model.id, first.id);
+
+const endpointsResult = await publicSession.client.callTool({
+  name: "list_model_endpoints",
+  arguments: { model: first.id, limit: 100 },
+});
+assertToolSuccess(endpointsResult, "list_model_endpoints");
+const endpoints = endpointsResult.structuredContent as {
+  endpoints: unknown[];
+  model: { id: string };
+};
+assert.equal(endpoints.model.id, first.id);
+
+const providersResult = await publicSession.client.callTool({
+  name: "list_providers",
+  arguments: { limit: 100, offset: 0 },
+});
+assertToolSuccess(providersResult, "list_providers");
+const providers = providersResult.structuredContent as {
+  providers: unknown[];
+  total_count: number;
+};
+assert.ok(providers.providers.length > 0);
+assert.ok(providers.total_count >= providers.providers.length);
+await publicSession.client.close();
+await publicSession.handler.close();
+
+const report: Record<string, unknown> = {
+  catalog: "pass",
+  mcp_protocol: "2026-07-28",
+  total_models: page.total_count,
+  sampled_model: first.id,
+  sampled_endpoints: endpoints.endpoints.length,
+  provider_count: providers.total_count,
+  rankings: "skipped: OPENROUTER_API_KEY is not configured",
+  free_inference: "skipped: OPENROUTER_API_KEY is not configured",
+  management: "skipped: OPENROUTER_MANAGEMENT_KEY is not configured",
+};
+
+if (process.env.OPENROUTER_API_KEY?.trim()) {
+  const authenticatedSession = await connectMcp(OpenRouterClient.fromEnvironment());
+  try {
+    const modelRankingsResult = await authenticatedSession.client.callTool({
+      name: "list_model_rankings",
+      arguments: { limit: 3 },
+    });
+    assertToolSuccess(modelRankingsResult, "list_model_rankings");
+    const modelRankings = modelRankingsResult.structuredContent as { rankings: unknown[] };
+
+    const appRankingsResult = await authenticatedSession.client.callTool({
+      name: "list_app_rankings",
+      arguments: { limit: 3, offset: 0, sort: "popular" },
+    });
+    assertToolSuccess(appRankingsResult, "list_app_rankings");
+    const appRankings = appRankingsResult.structuredContent as { apps: unknown[] };
+
+    report.rankings = "pass";
+    report.sampled_model_rankings = modelRankings.rankings.length;
+    report.sampled_app_rankings = appRankings.apps.length;
+  } catch (error) {
+    report.rankings = "fail";
+    report.rankings_error = { message: error instanceof Error ? error.message : String(error) };
+    process.exitCode = 1;
+  }
+
+  try {
+    const completionResult = await authenticatedSession.client.callTool({
+      name: "chat_with_model",
+      arguments: {
+        model: "openrouter/free",
+        message: "Reply with OK.",
+        max_completion_tokens: 4,
+        temperature: 0,
+      },
+    });
+    assertToolSuccess(completionResult, "chat_with_model");
+    const completion = completionResult.structuredContent as {
+      generation_id: string;
+      resolved_model: string | null;
+    };
+    assert.ok(completion.generation_id);
+    await new Promise<void>((resolve) => setTimeout(resolve, 750));
+    const generationResult = await authenticatedSession.client.callTool({
+      name: "get_generation",
+      arguments: { generation_id: completion.generation_id },
+    });
+    assertToolSuccess(generationResult, "get_generation");
+    const generation = generationResult.structuredContent as {
+      generation: {
+        id: string;
+        model?: string;
+        provider_name?: string | null;
+        total_cost?: number | null;
+      };
+    };
+    assert.equal(generation.generation.id, completion.generation_id);
+    report.free_inference = "pass";
+    report.resolved_model = completion.resolved_model ?? generation.generation.model ?? null;
+    report.provider = generation.generation.provider_name ?? null;
+    report.total_cost = generation.generation.total_cost ?? null;
+  } catch (error) {
+    report.free_inference = "fail";
+    report.inference_error = { message: error instanceof Error ? error.message : String(error) };
+    process.exitCode = 1;
+  } finally {
+    await authenticatedSession.client.close();
+    await authenticatedSession.handler.close();
+  }
+}
+
+if (process.env.OPENROUTER_MANAGEMENT_KEY?.trim()) {
+  const managementSession = await connectMcp(OpenRouterClient.fromEnvironment());
+  try {
+    const creditsResult = await managementSession.client.callTool({
+      name: "get_credits",
+      arguments: {},
+    });
+    assertToolSuccess(creditsResult, "get_credits");
+
+    const activityResult = await managementSession.client.callTool({
+      name: "list_activity",
+      arguments: { limit: 2, offset: 0 },
+    });
+    assertToolSuccess(activityResult, "list_activity");
+    const activity = activityResult.structuredContent as { activity: unknown[] };
+
+    const analyticsSchemaResult = await managementSession.client.callTool({
+      name: "get_analytics_schema",
+      arguments: {},
+    });
+    assertToolSuccess(analyticsSchemaResult, "get_analytics_schema");
+    const analyticsSchema = analyticsSchemaResult.structuredContent as {
+      schema: { dimensions: unknown[]; metrics: unknown[] };
+    };
+
+    const analyticsResult = await managementSession.client.callTool({
+      name: "query_analytics",
+      arguments: {
+        metrics: ["request_count"],
+        time_range: { start: utcBoundary(7), end: utcBoundary(0) },
+        limit: 2,
+      },
+    });
+    assertToolSuccess(analyticsResult, "query_analytics");
+    const analytics = analyticsResult.structuredContent as {
+      metadata: { row_count: number; truncated: boolean };
+    };
+
+    report.management = "pass";
+    report.sampled_activity = activity.activity.length;
+    report.analytics_dimensions = analyticsSchema.schema.dimensions.length;
+    report.analytics_metrics = analyticsSchema.schema.metrics.length;
+    report.analytics_rows = analytics.metadata.row_count;
+    report.analytics_truncated = analytics.metadata.truncated;
+  } catch (error) {
+    report.management = "fail";
+    report.management_error = { message: error instanceof Error ? error.message : String(error) };
+    process.exitCode = 1;
+  } finally {
+    await managementSession.client.close();
+    await managementSession.handler.close();
+  }
+}
+
+process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+
+async function connectMcp(api: OpenRouterApi) {
+  const handler = createOpenRouterMcpHandler(api);
+  const transport = new StreamableHTTPClientTransport(new URL("http://live-contract.local/mcp"), {
+    fetch: (url, init) => handler.fetch(new Request(url, init)),
+  });
+  const client = new Client(
+    { name: "openrouter-live-contract", version: "1.0.0" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } },
+  );
+  await client.connect(transport);
+  return { client, handler };
+}
+
+function assertToolSuccess(
+  result: { content: unknown[]; isError?: boolean; structuredContent?: unknown },
+  toolName: string,
+): asserts result is { content: unknown[]; structuredContent: Record<string, unknown> } {
+  if (result.isError || result.structuredContent === undefined) {
+    throw new Error(toolName + " failed: " + JSON.stringify(result.content));
+  }
+}
+
+function utcBoundary(daysAgo: number): string {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - daysAgo)).toISOString();
+}

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
 
@@ -9,11 +10,26 @@ import { createOpenRouterMcpHandler } from "../src/mcp.js";
 import {
   OpenRouterClient,
   OpenRouterHttpError,
+  type ActivityOptions,
+  type AppRankingsOptions,
   type ChatCompletionRequest,
   type ChatCompletionResult,
   type ListModelsOptions,
+  type ListModelsResult,
+  type ModelRankingsOptions,
   type OpenRouterApi,
+  type OpenRouterActivityItem,
+  type OpenRouterAnalyticsMeta,
+  type OpenRouterAnalyticsQuery,
+  type OpenRouterAnalyticsQueryResult,
+  type OpenRouterAppRankingItem,
+  type OpenRouterCredits,
+  type OpenRouterGeneration,
   type OpenRouterModel,
+  type OpenRouterModelEndpoints,
+  type OpenRouterModelRankingItem,
+  type OpenRouterProvider,
+  type RankingsResult,
 } from "../src/openrouter.js";
 
 const pricingWithOverrides: NonNullable<OpenRouterModel["pricing"]> = {
@@ -37,9 +53,23 @@ class FakeOpenRouterApi implements OpenRouterApi {
   readonly models: OpenRouterModel[] = [
     {
       id: "example/alpha",
+      canonical_slug: "example/alpha-20260831",
       name: "Alpha",
+      created: 1_788_206_780,
       context_length: 32_000,
+      architecture: {
+        input_modalities: ["text"],
+        output_modalities: ["text"],
+      },
+      benchmarks: {
+        artificial_analysis: {
+          intelligence_index: 60,
+          coding_index: 70,
+          agentic_index: 50,
+        },
+      },
       pricing: pricingWithOverrides,
+      top_provider: { max_completion_tokens: 8_000, is_moderated: false },
     },
     {
       id: "example/beta",
@@ -49,16 +79,211 @@ class FakeOpenRouterApi implements OpenRouterApi {
     },
   ];
 
-  listModelsHook?: (options: ListModelsOptions, signal?: AbortSignal) => Promise<OpenRouterModel[]>;
-  chatError?: Error;
+  readonly modelEndpoints: OpenRouterModelEndpoints = {
+    id: "example/alpha",
+    name: "Alpha",
+    endpoints: [
+      {
+        name: "First Cloud | Alpha",
+        provider_name: "First Cloud",
+        tag: "first/fp16",
+        context_length: 32_000,
+        pricing: pricingWithOverrides,
+        uptime_last_30m: 99.5,
+      },
+      {
+        name: "Second Cloud | Alpha",
+        provider_name: "Second Cloud",
+        tag: "second/bf16",
+        context_length: 32_000,
+        pricing: { prompt: "0.000002", completion: "0.000003" },
+        uptime_last_30m: 100,
+      },
+    ],
+  };
 
-  async listModels(options: ListModelsOptions, signal?: AbortSignal): Promise<OpenRouterModel[]> {
+  readonly providers: OpenRouterProvider[] = [
+    {
+      name: "First Cloud",
+      slug: "first-cloud",
+      headquarters: "US",
+      datacenters: ["US", "DE"],
+      privacy_policy_url: "https://first.example/privacy",
+      status_page_url: "https://status.first.example",
+      terms_of_service_url: "https://first.example/terms",
+    },
+    {
+      name: "Second Cloud",
+      slug: "second-cloud",
+      headquarters: "CA",
+      datacenters: ["CA"],
+      privacy_policy_url: null,
+    },
+  ];
+
+  readonly activity: OpenRouterActivityItem[] = [
+    {
+      byok_usage_inference: 0,
+      completion_tokens: 20,
+      date: "2026-08-30",
+      endpoint_id: "endpoint-first",
+      model: "example/alpha",
+      model_permaslug: "example/alpha-20260831",
+      prompt_tokens: 10,
+      provider_name: "First Cloud",
+      reasoning_tokens: 5,
+      requests: 2,
+      usage: 0.02,
+      workspace_id: "550e8400-e29b-41d4-a716-446655440000",
+    },
+    {
+      byok_usage_inference: 0.01,
+      completion_tokens: 40,
+      date: "2026-08-30",
+      endpoint_id: "endpoint-second",
+      model: "example/beta",
+      model_permaslug: "example/beta-20260831",
+      prompt_tokens: 30,
+      provider_name: "Second Cloud",
+      reasoning_tokens: 0,
+      requests: 1,
+      usage: 0.04,
+      workspace_id: "550e8400-e29b-41d4-a716-446655440000",
+    },
+  ];
+
+  readonly rankingsMeta = {
+    as_of: "2026-08-31T01:00:00Z",
+    start_date: "2026-08-30",
+    end_date: "2026-08-30",
+    version: "v1" as const,
+  };
+
+  readonly analyticsMeta: OpenRouterAnalyticsMeta = {
+    dimensions: [{ display_label: "Model", name: "model" }],
+    granularities: [{ display_label: "Day", name: "day" }],
+    metrics: [{ display_format: "currency", display_label: "Total Usage", is_rate: false, name: "total_usage" }],
+    operators: [{ name: "eq", value_type: "scalar" }],
+  };
+
+  lastListModelsOptions?: ListModelsOptions;
+  listModelsHook?: (options: ListModelsOptions, signal?: AbortSignal) => Promise<ListModelsResult>;
+  chatHook?: (request: ChatCompletionRequest, signal?: AbortSignal) => Promise<ChatCompletionResult>;
+  chatError?: Error;
+  getModelCalls = 0;
+
+  async listProviders(signal?: AbortSignal): Promise<OpenRouterProvider[]> {
+    signal?.throwIfAborted();
+    return this.providers;
+  }
+
+  async getCredits(signal?: AbortSignal): Promise<OpenRouterCredits> {
+    signal?.throwIfAborted();
+    return { total_credits: 100, total_usage: 25.5 };
+  }
+
+  async getActivity(
+    _options: ActivityOptions = {},
+    signal?: AbortSignal,
+  ): Promise<OpenRouterActivityItem[]> {
+    signal?.throwIfAborted();
+    return this.activity;
+  }
+
+  async getAnalyticsMeta(signal?: AbortSignal): Promise<OpenRouterAnalyticsMeta> {
+    signal?.throwIfAborted();
+    return this.analyticsMeta;
+  }
+
+  async queryAnalytics(
+    request: OpenRouterAnalyticsQuery,
+    signal?: AbortSignal,
+  ): Promise<OpenRouterAnalyticsQueryResult> {
+    signal?.throwIfAborted();
+    return {
+      rows: [{ model: "example/alpha", total_usage: 0.02, request_count: "2" }],
+      metadata: { query_time_ms: 4, row_count: 1, truncated: request.limit === 1 },
+    };
+  }
+
+  async getModelRankings(
+    _options: ModelRankingsOptions = {},
+    signal?: AbortSignal,
+  ): Promise<RankingsResult<OpenRouterModelRankingItem>> {
+    signal?.throwIfAborted();
+    return {
+      data: [
+        { date: "2026-08-30", model_permaslug: "example/alpha-20260831", total_tokens: "9000" },
+        { date: "2026-08-30", model_permaslug: "other", total_tokens: "1000" },
+      ],
+      meta: this.rankingsMeta,
+    };
+  }
+
+  async getAppRankings(
+    _options: AppRankingsOptions = {},
+    signal?: AbortSignal,
+  ): Promise<RankingsResult<OpenRouterAppRankingItem>> {
+    signal?.throwIfAborted();
+    return {
+      data: [{ app_id: 1, app_name: "Example CLI", rank: 1, total_requests: 10, total_tokens: "5000" }],
+      meta: this.rankingsMeta,
+    };
+  }
+
+  async listModels(options: ListModelsOptions = {}, signal?: AbortSignal): Promise<ListModelsResult> {
+    this.lastListModelsOptions = options;
     if (this.listModelsHook) {
       return this.listModelsHook(options, signal);
     }
     signal?.throwIfAborted();
     const query = options.q?.toLowerCase();
-    return query ? this.models.filter((model) => model.id.toLowerCase().includes(query)) : this.models;
+    const matching = query
+      ? this.models.filter(
+          (model) => model.id.toLowerCase().includes(query) || model.name?.toLowerCase().includes(query),
+        )
+      : this.models;
+    const offset = options.offset ?? 0;
+    const limit = options.limit ?? 25;
+    const models = matching.slice(offset, offset + limit);
+    return {
+      models,
+      totalCount: matching.length,
+      links: {
+        next: offset + models.length < matching.length ? "/models?offset=" + (offset + models.length) : null,
+      },
+    };
+  }
+
+  async getModel(modelId: string, signal?: AbortSignal): Promise<OpenRouterModel> {
+    signal?.throwIfAborted();
+    this.getModelCalls += 1;
+    const model = this.models.find((candidate) => candidate.id === modelId);
+    if (!model) {
+      throw new Error("OpenRouter model not found: " + modelId);
+    }
+    return model;
+  }
+
+  async getModelEndpoints(modelId: string, signal?: AbortSignal): Promise<OpenRouterModelEndpoints> {
+    signal?.throwIfAborted();
+    if (modelId !== this.modelEndpoints.id) {
+      throw new Error("OpenRouter model not found: " + modelId);
+    }
+    return this.modelEndpoints;
+  }
+
+  async getGeneration(generationId: string, signal?: AbortSignal): Promise<OpenRouterGeneration> {
+    signal?.throwIfAborted();
+    return {
+      id: generationId,
+      model: "example/alpha-resolved",
+      provider_name: "First Cloud",
+      tokens_prompt: 4,
+      tokens_completion: 5,
+      total_cost: 0.00001,
+      latency: 350,
+    };
   }
 
   async getCurrentKey(signal?: AbortSignal): Promise<Record<string, unknown>> {
@@ -71,11 +296,16 @@ class FakeOpenRouterApi implements OpenRouterApi {
     signal?: AbortSignal,
   ): Promise<ChatCompletionResult> {
     signal?.throwIfAborted();
+    if (this.chatHook) {
+      return this.chatHook(request, signal);
+    }
     if (this.chatError) {
       throw this.chatError;
     }
     return {
       content: "response from " + request.model,
+      generationId: "gen-" + request.model.replace("/", "-"),
+      resolvedModel: request.model + "-resolved",
       usage: { prompt_tokens: 4, completion_tokens: 5, total_tokens: 9 },
     };
   }
@@ -103,7 +333,16 @@ function createStdioTransport(): StdioClientTransport {
   });
 }
 
-test("serves MCP 2026-07-28 directly with structured, annotated tools", async (context) => {
+function createCliStdioTransport(): StdioClientTransport {
+  return new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", path.resolve("src/cli.ts"), "serve", "--transport", "stdio"],
+    cwd: process.cwd(),
+    stderr: "pipe",
+  });
+}
+
+test("serves focused MCP 2026-07-28 tools with upstream pagination and cache hints", async (context) => {
   const api = new FakeOpenRouterApi();
   const { client, handler } = await connectHttp(api);
   context.after(async () => {
@@ -113,8 +352,26 @@ test("serves MCP 2026-07-28 directly with structured, annotated tools", async (c
 
   assert.equal(client.getProtocolEra(), "modern");
   const listed = await client.listTools();
-  const names = listed.tools.map((tool) => tool.name);
-  assert.deepEqual(names, ["list_models", "chat_with_model", "compare_models", "get_model_info"]);
+  assert.deepEqual(
+    listed.tools.map((tool) => tool.name),
+    [
+      "list_models",
+      "get_model",
+      "list_model_endpoints",
+      "list_providers",
+      "list_model_rankings",
+      "list_app_rankings",
+      "get_credits",
+      "list_activity",
+      "get_analytics_schema",
+      "query_analytics",
+      "chat_with_model",
+      "compare_models",
+      "get_generation",
+    ],
+  );
+  assert.equal(listed.ttlMs, 3_600_000);
+  assert.equal(listed.cacheScope, "public");
 
   const listTool = listed.tools.find((tool) => tool.name === "list_models");
   assert.equal(listTool?.annotations?.readOnlyHint, true);
@@ -122,58 +379,304 @@ test("serves MCP 2026-07-28 directly with structured, annotated tools", async (c
 
   const result = await client.callTool({
     name: "list_models",
-    arguments: { limit: 1, offset: 0 },
+    arguments: {
+      limit: 1,
+      offset: 0,
+      providers: ["First Cloud"],
+      sort: "newest",
+      min_context_length: 16_000,
+    },
   });
   assert.equal(result.isError, undefined);
   assert.deepEqual(result.structuredContent, {
+    has_more: true,
     models: [
       {
         id: "example/alpha",
+        canonical_slug: "example/alpha-20260831",
         name: "Alpha",
+        created: 1_788_206_780,
         context_length: 32_000,
+        input_modalities: ["text"],
+        output_modalities: ["text"],
         pricing: pricingWithOverrides,
+        max_completion_tokens: 8_000,
+        intelligence_index: 60,
+        coding_index: 70,
+        agentic_index: 50,
       },
     ],
-    total_available: 2,
-    returned: 1,
-    offset: 0,
     next_offset: 1,
+    offset: 0,
+    returned: 1,
+    total_count: 2,
   });
+  assert.equal(api.lastListModelsOptions?.limit, 1);
+  assert.equal(api.lastListModelsOptions?.offset, 0);
+  assert.deepEqual(api.lastListModelsOptions?.providers, ["First Cloud"]);
+  assert.equal(api.lastListModelsOptions?.sort, "newest");
+  assert.equal(api.lastListModelsOptions?.minContextLength, 16_000);
 
-  const invalid = await client.callTool({
+  const invalidRange = await client.callTool({
     name: "list_models",
-    arguments: { limit: 0 },
+    arguments: { min_prompt_price: 10, max_prompt_price: 1 },
   });
-  assert.equal(invalid.isError, true);
+  assert.equal(invalidRange.isError, true);
 });
 
-test("preserves pricing override arrays in model and pricing resources", async (context) => {
+test("exposes only the bounded private usage resource", async (context) => {
   const { client, handler } = await connectHttp(new FakeOpenRouterApi());
   context.after(async () => {
     await client.close();
     await handler.close();
   });
 
-  const modelsResult = await client.readResource({ uri: "openrouter://models" });
-  const modelsContent = modelsResult.contents[0];
-  assert.ok(modelsContent && "text" in modelsContent);
-  const modelsPayload = JSON.parse(modelsContent.text) as {
-    data: Array<{ id: string; pricing?: NonNullable<OpenRouterModel["pricing"]> }>;
-  };
-  assert.equal(modelsPayload.data[0]?.id, "example/alpha");
-  assert.deepEqual(modelsPayload.data[0]?.pricing, pricingWithOverrides);
+  const listed = await client.listResources();
+  assert.deepEqual(listed.resources.map((resource) => resource.uri), ["openrouter://usage"]);
+  assert.equal(listed.ttlMs, 3_600_000);
+  assert.equal(listed.cacheScope, "public");
 
-  const pricingResult = await client.readResource({ uri: "openrouter://pricing" });
-  const pricingContent = pricingResult.contents[0];
-  assert.ok(pricingContent && "text" in pricingContent);
-  const pricingPayload = JSON.parse(pricingContent.text) as {
-    data: Array<{ id: string; pricing?: NonNullable<OpenRouterModel["pricing"]> }>;
-  };
-  assert.equal(pricingPayload.data[0]?.id, "example/alpha");
-  assert.deepEqual(pricingPayload.data[0]?.pricing, pricingWithOverrides);
+  const usageResult = await client.readResource({ uri: "openrouter://usage" });
+  assert.equal(usageResult.ttlMs, 5_000);
+  assert.equal(usageResult.cacheScope, "private");
+  const usageContent = usageResult.contents[0];
+  assert.ok(usageContent && "text" in usageContent);
+  assert.deepEqual(JSON.parse(usageContent.text), {
+    data: { label: "test-key", usage: 1.25, limit: 10 },
+  });
+
+  await assert.rejects(client.readResource({ uri: "openrouter://models" }));
+  await assert.rejects(client.readResource({ uri: "openrouter://pricing" }));
 });
 
-test("accepts a conformant modern tools/list request without initialize or session state", async () => {
+test("uses direct model, endpoint, and generation handles without server state", async (context) => {
+  const api = new FakeOpenRouterApi();
+  const { client, handler } = await connectHttp(api);
+  context.after(async () => {
+    await client.close();
+    await handler.close();
+  });
+
+  const model = await client.callTool({
+    name: "get_model",
+    arguments: { model: "example/alpha" },
+  });
+  assert.equal(api.getModelCalls, 1);
+  assert.deepEqual(model.structuredContent, { model: api.models[0] });
+
+  const endpoints = await client.callTool({
+    name: "list_model_endpoints",
+    arguments: { model: "example/alpha", provider: "second", limit: 1 },
+  });
+  assert.deepEqual(endpoints.structuredContent, {
+    endpoints: [api.modelEndpoints.endpoints[1]],
+    has_more: false,
+    model: { id: "example/alpha", name: "Alpha" },
+    next_offset: null,
+    offset: 0,
+    returned: 1,
+    total_count: 1,
+  });
+
+  const chat = await client.callTool({
+    name: "chat_with_model",
+    arguments: { model: "example/alpha", message: "Hello" },
+  });
+  assert.deepEqual(chat.structuredContent, {
+    generation_id: "gen-example-alpha",
+    requested_model: "example/alpha",
+    resolved_model: "example/alpha-resolved",
+    response: "response from example/alpha",
+    usage: { prompt_tokens: 4, completion_tokens: 5, total_tokens: 9 },
+  });
+
+  const generation = await client.callTool({
+    name: "get_generation",
+    arguments: { generation_id: "gen-example-alpha" },
+  });
+  assert.deepEqual(generation.structuredContent, {
+    generation: {
+      id: "gen-example-alpha",
+      model: "example/alpha-resolved",
+      provider_name: "First Cloud",
+      tokens_prompt: 4,
+      tokens_completion: 5,
+      total_cost: 0.00001,
+      latency: 350,
+    },
+  });
+
+  const invalidModel = await client.callTool({
+    name: "get_model",
+    arguments: { model: "missing-slash" },
+  });
+  assert.equal(invalidModel.isError, true);
+  assert.equal(api.getModelCalls, 1);
+});
+
+test("exposes former browser surfaces through bounded official API contracts", async (context) => {
+  const api = new FakeOpenRouterApi();
+  const { client, handler } = await connectHttp(api);
+  context.after(async () => {
+    await client.close();
+    await handler.close();
+  });
+
+  const providers = await client.callTool({
+    name: "list_providers",
+    arguments: { datacenter: "de", limit: 10 },
+  });
+  assert.deepEqual(providers.structuredContent, {
+    has_more: false,
+    next_offset: null,
+    offset: 0,
+    providers: [api.providers[0]],
+    returned: 1,
+    total_count: 1,
+  });
+
+  const modelRankings = await client.callTool({
+    name: "list_model_rankings",
+    arguments: { date: "2026-08-30", limit: 10 },
+  });
+  const modelRankingOutput = modelRankings.structuredContent as {
+    attribution: string;
+    rankings: Array<{ model_permaslug: string; rank: number }>;
+  };
+  assert.match(modelRankingOutput.attribution, /Source: OpenRouter/);
+  assert.deepEqual(modelRankingOutput.rankings, [
+    { date: "2026-08-30", model_permaslug: "example/alpha-20260831", rank: 1, total_tokens: "9000" },
+  ]);
+
+  const appRankings = await client.callTool({
+    name: "list_app_rankings",
+    arguments: { limit: 1, offset: 0, sort: "trending" },
+  });
+  assert.deepEqual(appRankings.structuredContent, {
+    apps: [{ app_id: 1, app_name: "Example CLI", rank: 1, total_requests: 10, total_tokens: "5000" }],
+    attribution: "Source: OpenRouter (openrouter.ai/apps), as of 2026-08-31T01:00:00Z.",
+    has_more: false,
+    meta: api.rankingsMeta,
+    next_offset: null,
+    offset: 0,
+    returned: 1,
+  });
+
+  const credits = await client.callTool({ name: "get_credits", arguments: {} });
+  assert.deepEqual(credits.structuredContent, {
+    total_credits: 100,
+    total_usage: 25.5,
+    remaining_credits: 74.5,
+  });
+
+  const activity = await client.callTool({
+    name: "list_activity",
+    arguments: { date: "2026-08-30", group_by: "workspace", limit: 1 },
+  });
+  assert.deepEqual(activity.structuredContent, {
+    activity: [api.activity[0]],
+    date: "2026-08-30",
+    has_more: true,
+    next_offset: 1,
+    offset: 0,
+    returned: 1,
+    total_count: 2,
+  });
+
+  const invalidHash = await client.callTool({
+    name: "list_activity",
+    arguments: { api_key_hash: "not-a-hash" },
+  });
+  assert.equal(invalidHash.isError, true);
+
+  const analyticsSchema = await client.callTool({ name: "get_analytics_schema", arguments: {} });
+  assert.deepEqual(analyticsSchema.structuredContent, { schema: api.analyticsMeta });
+
+  const analytics = await client.callTool({
+    name: "query_analytics",
+    arguments: {
+      metrics: ["total_usage", "request_count"],
+      dimensions: ["model"],
+      order_by: { field: "total_usage", direction: "desc" },
+      time_range: { start: "2026-08-01T00:00:00Z", end: "2026-08-31T00:00:00Z" },
+      limit: 10,
+    },
+  });
+  assert.deepEqual(analytics.structuredContent, {
+    rows: [{ model: "example/alpha", total_usage: 0.02, request_count: "2" }],
+    metadata: { query_time_ms: 4, row_count: 1, truncated: false },
+  });
+
+  const invalidAnalytics = await client.callTool({
+    name: "query_analytics",
+    arguments: {
+      metrics: ["total_usage"],
+      dimensions: ["model", "provider", "workspace"],
+      time_range: { start: "2026-08-31T00:00:00Z", end: "2026-08-01T00:00:00Z" },
+    },
+  });
+  assert.equal(invalidAnalytics.isError, true);
+});
+
+test("caps paid comparison concurrency at three and returns per-call generation IDs", async (context) => {
+  const api = new FakeOpenRouterApi();
+  let active = 0;
+  let maximumActive = 0;
+  const calls = new Map<string, number>();
+  api.chatHook = async (request, signal) => {
+    signal?.throwIfAborted();
+    calls.set(request.model, (calls.get(request.model) ?? 0) + 1);
+    active += 1;
+    maximumActive = Math.max(maximumActive, active);
+    try {
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      if (request.model.endsWith("/5")) {
+        throw new Error("provider rejected model");
+      }
+      return {
+        content: "answer " + request.model,
+        generationId: "gen-" + request.model.replace("/", "-"),
+        resolvedModel: request.model,
+      };
+    } finally {
+      active -= 1;
+    }
+  };
+
+  const { client, handler } = await connectHttp(api);
+  context.after(async () => {
+    await client.close();
+    await handler.close();
+  });
+
+  const models = Array.from({ length: 8 }, (_, index) => "example/" + index);
+  const comparison = await client.callTool({
+    name: "compare_models",
+    arguments: { models, message: "Compare" },
+  });
+  assert.equal(comparison.isError, undefined);
+  assert.ok(maximumActive <= 3);
+  assert.deepEqual([...calls.values()], Array.from({ length: 8 }, () => 1));
+  const payload = comparison.structuredContent as {
+    results: Array<{ error?: string; generation_id?: string; requested_model: string; success: boolean }>;
+  };
+  assert.equal(payload.results.length, 8);
+  assert.deepEqual(payload.results[0], {
+    generation_id: "gen-example-0",
+    requested_model: "example/0",
+    resolved_model: "example/0",
+    success: true,
+    response: "answer example/0",
+    usage: null,
+  });
+  assert.deepEqual(payload.results[5], {
+    requested_model: "example/5",
+    success: false,
+    error: "provider rejected model",
+  });
+});
+
+test("accepts a modern tools/list request without initialize or session state", async () => {
   const handler = createOpenRouterMcpHandler(new FakeOpenRouterApi());
   try {
     const response = await handler.fetch(
@@ -206,10 +709,12 @@ test("accepts a conformant modern tools/list request without initialize or sessi
     assert.equal(response.status, 200);
     const body = (await response.json()) as {
       id: number;
-      result: { tools: Array<{ name: string }> };
+      result: { cacheScope: string; tools: Array<{ name: string }>; ttlMs: number };
     };
     assert.equal(body.id, 7);
-    assert.ok(body.result.tools.some((tool) => tool.name === "list_models"));
+    assert.equal(body.result.ttlMs, 3_600_000);
+    assert.equal(body.result.cacheScope, "public");
+    assert.ok(body.result.tools.some((tool) => tool.name === "list_model_endpoints"));
     assert.equal(response.headers.has("Mcp-Session-Id"), false);
   } finally {
     await handler.close();
@@ -251,7 +756,7 @@ test("converts upstream tool failures into MCP tool errors", async (context) => 
   assert.match(JSON.stringify(result.content), /upstream unavailable/);
 });
 
-test("forwards MCP cancellation to the in-flight OpenRouter operation", async (context) => {
+test("forwards MCP cancellation to the in-flight paginated OpenRouter operation", async (context) => {
   const api = new FakeOpenRouterApi();
   let observedSignal: AbortSignal | undefined;
   let markStarted: (() => void) | undefined;
@@ -261,7 +766,7 @@ test("forwards MCP cancellation to the in-flight OpenRouter operation", async (c
   api.listModelsHook = async (_options, signal) => {
     observedSignal = signal;
     markStarted?.();
-    return new Promise<OpenRouterModel[]>((_resolve, reject) => {
+    return new Promise<ListModelsResult>((_resolve, reject) => {
       if (!signal) {
         reject(new Error("Expected an MCP cancellation signal."));
         return;
@@ -305,7 +810,25 @@ test("negotiates the modern protocol over the real stdio entry point", async () 
     await client.connect(transport);
     assert.equal(client.getProtocolEra(), "modern");
     const listed = await client.listTools();
-    assert.ok(listed.tools.some((tool) => tool.name === "get_model_info"));
+    assert.ok(listed.tools.some((tool) => tool.name === "get_generation"));
+  } finally {
+    await client.close();
+  }
+});
+
+test("serves the modern stateless protocol through the hybrid CLI entry point", async () => {
+  const client = new Client(
+    { name: "openrouter-cli-stdio-test", version: "1.0.0" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } },
+  );
+  const transport = createCliStdioTransport();
+
+  try {
+    await client.connect(transport);
+    assert.equal(client.getProtocolEra(), "modern");
+    const listed = await client.listTools();
+    assert.equal(listed.tools.length, 13);
+    assert.ok(listed.tools.some((tool) => tool.name === "query_analytics"));
   } finally {
     await client.close();
   }
@@ -325,7 +848,7 @@ test("rejects legacy initialization over the real stdio entry point", { timeout:
   }
 });
 
-test("uses current OpenRouter headers and max_completion_tokens", async () => {
+test("uses current OpenRouter headers and returns generation handles", async () => {
   let capturedUrl = "";
   let capturedInit: RequestInit | undefined;
   const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -333,6 +856,8 @@ test("uses current OpenRouter headers and max_completion_tokens", async () => {
     capturedInit = init;
     return new Response(
       JSON.stringify({
+        id: "gen-live-shape",
+        model: "example/alpha-resolved",
         choices: [{ message: { content: "hello" } }],
         usage: { total_tokens: 3 },
       }),
@@ -358,6 +883,8 @@ test("uses current OpenRouter headers and max_completion_tokens", async () => {
   });
 
   assert.equal(result.content, "hello");
+  assert.equal(result.generationId, "gen-live-shape");
+  assert.equal(result.resolvedModel, "example/alpha-resolved");
   assert.equal(capturedUrl, "https://openrouter.example/api/v1/chat/completions");
   const headers = new Headers(capturedInit?.headers);
   assert.equal(headers.get("Authorization"), "Bearer test-secret");
@@ -369,49 +896,351 @@ test("uses current OpenRouter headers and max_completion_tokens", async () => {
   assert.equal("max_tokens" in requestBody, false);
 });
 
-test("accepts current pricing override arrays from the models endpoint", async () => {
-  const fetchImpl = (async (): Promise<Response> =>
-    new Response(
+test("passes current model filters upstream and strips additive vendor fields", async () => {
+  let capturedUrl = "";
+  const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+    capturedUrl = String(input);
+    return new Response(
       JSON.stringify({
         data: [
           {
             id: "example/overridden",
             name: "Overridden pricing model",
-            pricing: pricingWithOverrides,
+            future_model_field: "must not leak",
+            pricing: {
+              ...pricingWithOverrides,
+              future_price_field: "must not leak",
+              overrides: pricingWithOverrides.overrides?.map((override) => ({
+                ...override,
+                future_override_field: "must not leak",
+              })),
+            },
           },
         ],
+        total_count: 150,
+        links: { next: "/api/v1/models?offset=11&limit=1", future_link: true },
+        future_response_field: true,
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
-    )) as typeof globalThis.fetch;
+    );
+  }) as typeof globalThis.fetch;
   const client = new OpenRouterClient({
     baseUrl: "https://openrouter.example/api/v1",
     fetch: fetchImpl,
   });
 
-  const models = await client.listModels();
-  assert.equal(models[0]?.id, "example/overridden");
-  assert.deepEqual(models[0]?.pricing, pricingWithOverrides);
+  const page = await client.listModels({
+    offset: 10,
+    limit: 1,
+    q: "alpha",
+    category: "programming",
+    supportedParameters: ["tools", "structured_outputs"],
+    outputModalities: ["text", "image"],
+    inputModalities: ["text", "file"],
+    sort: "coding-high-to-low",
+    minContextLength: 128_000,
+    minPromptPrice: 0,
+    maxPromptPrice: 2,
+    minOutputPrice: 0,
+    maxOutputPrice: 5,
+    architecture: "Claude",
+    modelAuthors: ["anthropic"],
+    providers: ["Anthropic", "Bedrock"],
+    distillable: false,
+    zdr: true,
+    region: "us",
+    minAgeDays: 1,
+    maxAgeDays: 90,
+    minIntelligenceIndex: 50,
+    maxCodingIndex: 100,
+    minAgenticIndex: 40,
+    maxToolSuccessRate: 1,
+  });
+
+  const url = new URL(capturedUrl);
+  assert.equal(url.searchParams.get("offset"), "10");
+  assert.equal(url.searchParams.get("limit"), "1");
+  assert.equal(url.searchParams.get("q"), "alpha");
+  assert.equal(url.searchParams.get("supported_parameters"), "tools,structured_outputs");
+  assert.equal(url.searchParams.get("output_modalities"), "text,image");
+  assert.equal(url.searchParams.get("input_modalities"), "text,file");
+  assert.equal(url.searchParams.get("sort"), "coding-high-to-low");
+  assert.equal(url.searchParams.get("context"), "128000");
+  assert.equal(url.searchParams.get("model_authors"), "anthropic");
+  assert.equal(url.searchParams.get("providers"), "Anthropic,Bedrock");
+  assert.equal(url.searchParams.get("distillable"), "false");
+  assert.equal(url.searchParams.get("zdr"), "true");
+  assert.equal(url.searchParams.get("region"), "us");
+  assert.equal(url.searchParams.get("min_age_days"), "1");
+  assert.equal(url.searchParams.get("max_age_days"), "90");
+  assert.equal(url.searchParams.get("min_intelligence_index"), "50");
+  assert.equal(url.searchParams.get("max_coding_index"), "100");
+  assert.equal(url.searchParams.get("min_agentic_index"), "40");
+  assert.equal(url.searchParams.get("max_tool_success_rate"), "1");
+  assert.equal(page.totalCount, 150);
+  assert.equal(page.models[0]?.id, "example/overridden");
+  assert.deepEqual(page.models[0]?.pricing, pricingWithOverrides);
+  assert.equal("future_model_field" in (page.models[0] ?? {}), false);
+  assert.equal("future_price_field" in (page.models[0]?.pricing ?? {}), false);
+  assert.equal("future_override_field" in (page.models[0]?.pricing?.overrides?.[0] ?? {}), false);
+});
+
+test("uses direct model, endpoint, and generation API routes", async () => {
+  const capturedUrls: string[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = new URL(String(input));
+    capturedUrls.push(url.href);
+    if (url.pathname.includes("/model/")) {
+      return Response.json({ data: { id: "example/alpha:free", name: "Alpha Free" } });
+    }
+    if (url.pathname.endsWith("/endpoints")) {
+      return Response.json({
+        data: {
+          id: "example/alpha:free",
+          endpoints: [{ name: "Free Cloud | Alpha", provider_name: "Free Cloud" }],
+        },
+      });
+    }
+    return Response.json({
+      data: {
+        id: url.searchParams.get("id"),
+        model: "example/alpha",
+        provider_name: "Free Cloud",
+        total_cost: 0,
+      },
+    });
+  }) as typeof globalThis.fetch;
+  const client = new OpenRouterClient({
+    apiKey: "test-secret",
+    baseUrl: "https://openrouter.example/api/v1",
+    fetch: fetchImpl,
+  });
+
+  const model = await client.getModel("example/alpha:free");
+  const endpoints = await client.getModelEndpoints("example/alpha:free");
+  const generation = await client.getGeneration("gen-123");
+
+  assert.equal(model.id, "example/alpha:free");
+  assert.equal(endpoints.endpoints[0]?.provider_name, "Free Cloud");
+  assert.equal(generation.id, "gen-123");
+  assert.match(capturedUrls[0] ?? "", /\/api\/v1\/model\/example\/alpha%3Afree$/);
+  assert.match(capturedUrls[1] ?? "", /\/api\/v1\/models\/example\/alpha%3Afree\/endpoints$/);
+  assert.match(capturedUrls[2] ?? "", /\/api\/v1\/generation\?id=gen-123$/);
+});
+
+test("uses official dashboard-era routes with separated API and management credentials", async () => {
+  const calls: Array<{ authorization: string | null; body?: string; method?: string; url: URL }> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = new URL(String(input));
+    calls.push({
+      authorization: new Headers(init?.headers).get("Authorization"),
+      body: typeof init?.body === "string" ? init.body : undefined,
+      method: init?.method,
+      url,
+    });
+    if (url.pathname.endsWith("/providers")) {
+      return Response.json({
+        data: [{ name: "First Cloud", slug: "first-cloud", privacy_policy_url: null, future: true }],
+      });
+    }
+    if (url.pathname.endsWith("/credits")) {
+      return Response.json({ data: { total_credits: 10, total_usage: 3, future: true } });
+    }
+    if (url.pathname.endsWith("/activity")) {
+      return Response.json({
+        data: [{
+          byok_usage_inference: 0,
+          completion_tokens: 2,
+          date: "2026-08-30",
+          endpoint_id: "endpoint",
+          model: "example/alpha",
+          model_permaslug: "example/alpha-20260831",
+          prompt_tokens: 1,
+          provider_name: "First Cloud",
+          reasoning_tokens: 0,
+          requests: 1,
+          usage: 0.01,
+          future: true,
+        }],
+      });
+    }
+    if (url.pathname.endsWith("/datasets/rankings-daily")) {
+      return Response.json({
+        data: [{ date: "2026-08-30", model_permaslug: "example/alpha", total_tokens: "3" }],
+        meta: { as_of: "2026-08-31T00:00:00Z", start_date: "2026-08-30", end_date: "2026-08-30", version: "v1" },
+      });
+    }
+    if (url.pathname.endsWith("/analytics/meta")) {
+      return Response.json({
+        data: {
+          dimensions: [{ display_label: "Model", name: "model", future: true }],
+          granularities: [{ display_label: "Day", name: "day" }],
+          metrics: [{ display_format: "currency", display_label: "Usage", is_rate: false, name: "total_usage" }],
+          operators: [{ name: "eq", value_type: "scalar" }],
+          future: true,
+        },
+      });
+    }
+    if (url.pathname.endsWith("/analytics/query")) {
+      return Response.json({
+        data: {
+          cachedAt: 123,
+          data: [{ model: "example/alpha", total_usage: 0.01 }],
+          metadata: { query_time_ms: 5, row_count: 1, truncated: false, future: true },
+          warnings: ["example warning"],
+          future: true,
+        },
+      });
+    }
+    return Response.json({
+      data: [{ app_id: 1, app_name: "Example", rank: 1, total_requests: 2, total_tokens: "3" }],
+      meta: { as_of: "2026-08-31T00:00:00Z", start_date: "2026-08-01", end_date: "2026-08-30", version: "v1" },
+    });
+  }) as typeof globalThis.fetch;
+  const client = new OpenRouterClient({
+    apiKey: "api-secret",
+    managementApiKey: "management-secret",
+    baseUrl: "https://openrouter.example/api/v1",
+    fetch: fetchImpl,
+  });
+
+  const providers = await client.listProviders();
+  const credits = await client.getCredits();
+  const activity = await client.getActivity({ date: "2026-08-30", groupBy: "workspace" });
+  const models = await client.getModelRankings({ startDate: "2026-08-30", endDate: "2026-08-30" });
+  const apps = await client.getAppRankings({ limit: 10, offset: 5, sort: "trending" });
+  const analyticsMeta = await client.getAnalyticsMeta();
+  const analytics = await client.queryAnalytics({
+    dimensions: ["model"],
+    limit: 10,
+    metrics: ["total_usage"],
+    time_range: { start: "2026-08-01T00:00:00Z", end: "2026-08-31T00:00:00Z" },
+  });
+
+  assert.deepEqual(providers, [{ name: "First Cloud", slug: "first-cloud", privacy_policy_url: null }]);
+  assert.deepEqual(credits, { total_credits: 10, total_usage: 3 });
+  assert.equal("future" in (activity[0] ?? {}), false);
+  assert.equal(models.data[0]?.total_tokens, "3");
+  assert.equal(apps.data[0]?.app_name, "Example");
+  assert.equal("future" in (analyticsMeta.dimensions[0] ?? {}), false);
+  assert.deepEqual(analytics, {
+    cached_at: 123,
+    rows: [{ model: "example/alpha", total_usage: 0.01 }],
+    metadata: { query_time_ms: 5, row_count: 1, truncated: false },
+    warnings: ["example warning"],
+  });
+  assert.equal(calls[0]?.authorization, null);
+  assert.equal(calls[1]?.authorization, "Bearer management-secret");
+  assert.equal(calls[2]?.authorization, "Bearer management-secret");
+  assert.equal(calls[3]?.authorization, "Bearer api-secret");
+  assert.equal(calls[4]?.authorization, "Bearer api-secret");
+  assert.equal(calls[5]?.authorization, "Bearer management-secret");
+  assert.equal(calls[6]?.authorization, "Bearer management-secret");
+  assert.equal(calls[2]?.url.searchParams.get("group_by"), "workspace");
+  assert.equal(calls[3]?.url.pathname, "/api/v1/datasets/rankings-daily");
+  assert.equal(calls[4]?.url.searchParams.get("offset"), "5");
+  assert.equal(calls[4]?.url.searchParams.get("sort"), "trending");
+  assert.equal(calls[5]?.url.pathname, "/api/v1/analytics/meta");
+  assert.equal(calls[6]?.url.pathname, "/api/v1/analytics/query");
+  assert.equal(calls[6]?.method, "POST");
+  assert.deepEqual(JSON.parse(calls[6]?.body ?? "{}"), {
+    dimensions: ["model"],
+    limit: 10,
+    metrics: ["total_usage"],
+    time_range: { start: "2026-08-01T00:00:00Z", end: "2026-08-31T00:00:00Z" },
+  });
+});
+
+test("ships an agent-readable CLI schema with automatic JSON output", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", path.resolve("src/cli.ts"), "schema"],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout) as {
+    command: string;
+    data: {
+      commands: Array<{ command: string; mcp_tool: string | null; options: string[]; usage: string }>;
+      exit_codes: { operation_failed: number; success: number; usage_error: number };
+      mcp_protocol: string;
+      output_contract: { mode: string };
+    };
+    ok: boolean;
+  };
+  assert.equal(output.ok, true);
+  assert.equal(output.command, "schema");
+  assert.equal(output.data.mcp_protocol, "2026-07-28");
+  assert.deepEqual(output.data.exit_codes, { success: 0, operation_failed: 1, usage_error: 2 });
+  assert.match(output.data.output_contract.mode, /JSON/);
+  assert.ok(output.data.commands.some((command) =>
+    command.command === "activity list" &&
+    command.mcp_tool === "list_activity" &&
+    command.usage === "activity list [options]" &&
+    command.options.includes("--workspace-id")
+  ));
+  assert.ok(output.data.commands.some((command) => command.command === "serve" && command.mcp_tool === null));
+});
+
+test("returns structured CLI usage errors with exit status two", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      path.resolve("src/cli.ts"),
+      "analytics",
+      "query",
+      "--metrics",
+      "total_usage",
+      "--start",
+      "not-a-timestamp",
+      "--end",
+      "2026-08-31T00:00:00Z",
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "");
+  const output = JSON.parse(result.stderr) as { error: { code: string; message: string }; ok: boolean };
+  assert.equal(output.ok, false);
+  assert.equal(output.error.code, "usage_error");
+  assert.match(output.error.message, /ISO 8601 UTC/);
 });
 
 test("rejects malformed pricing override containers", async () => {
   const fetchImpl = (async (): Promise<Response> =>
-    new Response(
-      JSON.stringify({
-        data: [
-          {
-            id: "example/malformed",
-            pricing: { prompt: "0", completion: "0", overrides: { prompt: "0" } },
-          },
-        ],
-      }),
-      { status: 200, headers: { "Content-Type": "application/json" } },
-    )) as typeof globalThis.fetch;
+    Response.json({
+      data: [
+        {
+          id: "example/malformed",
+          pricing: { prompt: "0", completion: "0", overrides: { prompt: "0" } },
+        },
+      ],
+      total_count: 1,
+      links: {},
+    })) as typeof globalThis.fetch;
   const client = new OpenRouterClient({
     baseUrl: "https://openrouter.example/api/v1",
     fetch: fetchImpl,
   });
 
   await assert.rejects(client.listModels());
+});
+
+test("requires HTTPS for non-loopback OpenRouter base URLs", () => {
+  assert.throws(
+    () => new OpenRouterClient({ baseUrl: "http://openrouter.example/api/v1" }),
+    /must use HTTPS/,
+  );
+  assert.throws(
+    () => new OpenRouterClient({ baseUrl: "https://user:pass@openrouter.example/api/v1" }),
+    /must not contain credentials/,
+  );
+  assert.doesNotThrow(() => new OpenRouterClient({ baseUrl: "http://127.0.0.1:8787/api/v1" }));
+  assert.doesNotThrow(() => new OpenRouterClient({ baseUrl: "http://localhost:8787/api/v1" }));
 });
 
 test("surfaces bounded OpenRouter HTTP errors without leaking request credentials", async () => {
@@ -434,3 +1263,21 @@ test("surfaces bounded OpenRouter HTTP errors without leaking request credential
       !error.message.includes("credential-that-must-not-appear"),
   );
 });
+
+test(
+  "matches the live public OpenRouter catalog contract",
+  { skip: process.env.OPENROUTER_LIVE_TEST !== "1", timeout: 20_000 },
+  async () => {
+    const client = OpenRouterClient.fromEnvironment();
+    const page = await client.listModels({ limit: 2, offset: 0, sort: "newest" });
+    assert.equal(page.models.length, 2);
+    assert.ok(page.totalCount >= page.models.length);
+    const first = page.models[0];
+    assert.ok(first);
+    const model = await client.getModel(first.id);
+    assert.equal(model.id, first.id);
+    const endpoints = await client.getModelEndpoints(first.id);
+    assert.equal(endpoints.id, first.id);
+    assert.ok(Array.isArray(endpoints.endpoints));
+  },
+);


### PR DESCRIPTION
## Summary
- implement strict MCP 2026-07-28 over HTTP and stdio without legacy fallback
- expose 13 bounded tools and one private usage resource through a shared operations layer
- add a non-interactive CLI over the same operations
- separate public discovery, inference-key, and management-key routes
- document migration boundaries and replace unsupported Markdown tables with readable grouped sections

## Breaking changes
- remove get_model_info, max_tokens, openrouter://models, and openrouter://pricing compatibility paths
- require Node.js 24 or newer

## Verification
- pnpm run check: typecheck, lint, 21 passing tests, one live-only skip, and build
- pnpm pack --dry-run: 18 intended package files
- no OpenRouter-style secret values in the release allowlist
- public live discovery was verified during the dated release check; the temporary inference key returned HTTP 401 and no management-key flow was available

No npm publication or production deployment is included in this PR.